### PR TITLE
nbdserver tlogStorage flush rework

### DIFF
--- a/nbdserver/ardb/ardb_test.go
+++ b/nbdserver/ardb/ardb_test.go
@@ -481,24 +481,24 @@ func testBackendStorageDeadlock(t *testing.T, blockSize, blockCount int64, stora
 		for i := int64(0); i < blockCount; i += 2 {
 			blockIndex := i
 			wg.Add(1)
-			go func() {
+			go func(curTime int64) {
 				defer wg.Done()
 
 				// get preContent
 				preContent, err := storage.Get(blockIndex)
 				if err != nil {
-					t.Fatal(time, blockIndex, err)
+					t.Fatal(curTime, blockIndex, err)
 					return
 				}
 
 				// merge it
-				offset := 2 + time
+				offset := 2 + curTime
 				blockIndex = (blockIndex + 1) % blockCount
 				err = storage.Merge(blockIndex, offset, preContent)
 				if err != nil {
-					t.Fatal(time, blockIndex, err)
+					t.Fatal(curTime, blockIndex, err)
 				}
-			}()
+			}(time)
 		}
 	}
 

--- a/nbdserver/ardb/tlog.go
+++ b/nbdserver/ardb/tlog.go
@@ -115,13 +115,17 @@ func (tls *tlogStorage) Set(blockIndex int64, content []byte) error {
 			blockIndex, sequence, err)
 	}
 
+	// copy the content to avoid race condition with value in cache
+	transactionContent := make([]byte, len(content))
+	copy(transactionContent, content)
+
 	// scheduele tlog transaction, to be sent to the server
 	tls.transactionCh <- &transaction{
 		Operation: op,
 		Sequence:  sequence,
 		Offset:    uint64(blockIndex * tls.blockSize),
 		Timestamp: uint64(time.Now().Unix()),
-		Content:   content,
+		Content:   transactionContent,
 		Size:      length,
 	}
 


### PR DESCRIPTION
Fixes #227 
- fix misuse of global variable inside a closure in ardb_test
- replace the `ForceFlush` + busy waiting with `ForceFlushAtSeq` + condition variable.
