### PR TITLE
support missing vdisk properties

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -310,7 +310,7 @@ const (
 // based on /docs/README.md#zero-os-0-disk
 const (
 	VdiskTypeBoot  = propDeduped | propPersistent | propRedundant | propTemplateSupport | propRollback
-	VdiskTypeDB    = propPersistent | propRedundant | propRollback | propOptimized
+	VdiskTypeDB    = propPersistent | propRedundant | propRollback | propTemplateSupport | propOptimized
 	VdiskTypeCache = propPersistent | propOptimized
 	VdiskTypeTmp   = propOptimized
 )

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-yaml/yaml"
@@ -407,24 +408,45 @@ var invalidVdiskTypes = []string{
 	"123",
 }
 var validVDiskTypeCases = []struct {
-	Input    string
-	Expected VdiskType
+	String string
+	Type   VdiskType
 }{
-	{string(VdiskTypeBoot), VdiskTypeBoot},
-	{string(VdiskTypeCache), VdiskTypeCache},
-	{string(VdiskTypeDB), VdiskTypeDB},
-	{string(VdiskTypeTmp), VdiskTypeTmp},
+	{vdiskTypeBootStr, VdiskTypeBoot},
+	{vdiskTypeCacheStr, VdiskTypeCache},
+	{vdiskTypeDBStr, VdiskTypeDB},
+	{vdiskTypeTmpStr, VdiskTypeTmp},
+}
+
+func TestVdiskTypeValidate(t *testing.T) {
+	for _, validCase := range validVDiskTypeCases {
+		assert.NoError(t, validCase.Type.Validate())
+	}
+
+	assert.Error(t, VdiskType(0).Validate())
+	assert.Error(t, VdiskType(255).Validate())
 }
 
 func TestValidVdiskTypeDeserialization(t *testing.T) {
 	var vdiskType VdiskType
 	for _, validCase := range validVDiskTypeCases {
-		err := yaml.Unmarshal([]byte(validCase.Input), &vdiskType)
-		if !assert.NoError(t, err, "unexpected invalid type: %q", validCase.Input) {
+		err := yaml.Unmarshal([]byte(validCase.String), &vdiskType)
+		if !assert.NoError(t, err, "unexpected invalid type: %q", validCase.String) {
 			continue
 		}
 
-		assert.Equal(t, validCase.Expected, vdiskType)
+		assert.Equal(t, validCase.Type, vdiskType)
+	}
+}
+
+func TestValidVdiskTypeSerialization(t *testing.T) {
+	for _, validCase := range validVDiskTypeCases {
+		bytes, err := yaml.Marshal(validCase.Type)
+		if !assert.NoError(t, err) {
+			continue
+		}
+
+		str := strings.Trim(string(bytes), "\n")
+		assert.Equal(t, validCase.String, str)
 	}
 }
 
@@ -434,6 +456,30 @@ func TestInvalidVdiskTypeDeserialization(t *testing.T) {
 		err := yaml.Unmarshal([]byte(invalidType), &vdiskType)
 		assert.Error(t, err, "unexpected valid type: %q", invalidType)
 	}
+}
+
+func TestVdiskProperties(t *testing.T) {
+	v := func(t VdiskType) *VdiskConfig {
+		return &VdiskConfig{Type: t}
+	}
+
+	// validate storage type property
+	assert.Equal(t, StorageDeduped, v(VdiskTypeBoot).StorageType())
+	assert.Equal(t, StorageNondeduped, v(VdiskTypeDB).StorageType())
+	assert.Equal(t, StorageNondeduped, v(VdiskTypeCache).StorageType())
+	assert.Equal(t, StorageNondeduped, v(VdiskTypeTmp).StorageType())
+
+	// validate redundant property
+	assert.True(t, v(VdiskTypeBoot).Redundant())
+	assert.True(t, v(VdiskTypeDB).Redundant())
+	assert.False(t, v(VdiskTypeCache).Redundant())
+	assert.False(t, v(VdiskTypeTmp).Redundant())
+
+	// validate template support
+	assert.True(t, v(VdiskTypeBoot).TemplateSupport())
+	assert.False(t, v(VdiskTypeDB).TemplateSupport())
+	assert.False(t, v(VdiskTypeCache).TemplateSupport())
+	assert.False(t, v(VdiskTypeTmp).TemplateSupport())
 }
 
 func TestParseValidCSStorageServerConfigStrings(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -477,7 +477,7 @@ func TestVdiskProperties(t *testing.T) {
 
 	// validate template support
 	assert.True(t, v(VdiskTypeBoot).TemplateSupport())
-	assert.False(t, v(VdiskTypeDB).TemplateSupport())
+	assert.True(t, v(VdiskTypeDB).TemplateSupport())
 	assert.False(t, v(VdiskTypeCache).TemplateSupport())
 	assert.False(t, v(VdiskTypeTmp).TemplateSupport())
 }

--- a/nbdserver/ardb/ardb.go
+++ b/nbdserver/ardb/ardb.go
@@ -111,9 +111,11 @@ func (f *BackendFactory) NewBackend(ctx context.Context, ec *nbd.ExportConfig) (
 	// GridAPI returns the vdisk size in GiB
 	vdiskSize := int64(vdisk.Size) * gibibyteAsBytes
 
+	templateSupport := vdisk.TemplateSupport()
+
 	switch storageType := vdisk.StorageType(); storageType {
 	case config.StorageNondeduped:
-		storage = newNonDedupedStorage(vdiskID, blockSize, redisProvider)
+		storage = newNonDedupedStorage(vdiskID, blockSize, templateSupport, redisProvider)
 	case config.StorageDeduped:
 		cacheLimit := f.lbaCacheLimit
 		if cacheLimit < lba.BytesPerShard {
@@ -140,7 +142,8 @@ func (f *BackendFactory) NewBackend(ctx context.Context, ec *nbd.ExportConfig) (
 			return
 		}
 
-		storage = newDedupedStorage(vdiskID, blockSize, redisProvider, vlba)
+		storage = newDedupedStorage(
+			vdiskID, blockSize, redisProvider, templateSupport, vlba)
 	default:
 		err = fmt.Errorf("unsupported vdisk storage type %q", storageType)
 	}

--- a/nbdserver/ardb/nondeduped.go
+++ b/nbdserver/ardb/nondeduped.go
@@ -4,27 +4,38 @@ import (
 	"context"
 
 	"github.com/zero-os/0-Disk/log"
-
-	"github.com/garyburd/redigo/redis"
 )
 
 // newNonDedupedStorage returns the non deduped backendStorage implementation
-func newNonDedupedStorage(vdiskID string, blockSize int64, provider redisConnectionProvider) backendStorage {
-	return &nonDedupedStorage{
+func newNonDedupedStorage(vdiskID string, blockSize int64, templateSupport bool, provider redisConnectionProvider) backendStorage {
+	nondeduped := &nonDedupedStorage{
 		blockSize: blockSize,
 		vdiskID:   vdiskID,
 		provider:  provider,
 	}
+
+	if templateSupport {
+		nondeduped.getContent = nondeduped.getLocalOrRemoteContent
+	} else {
+		nondeduped.getContent = nondeduped.getLocalContent
+	}
+
+	return nondeduped
 }
 
 // nonDedupedStorage is a backendStorage implementation,
 // that simply stores each block in redis using
 // a unique key based on the vdiskID and blockIndex
 type nonDedupedStorage struct {
-	blockSize int64
-	vdiskID   string
-	provider  redisConnectionProvider
+	blockSize  int64
+	vdiskID    string
+	provider   redisConnectionProvider
+	getContent nondedupedContentGetter
 }
+
+// used to provide different content getters based on the vdisk properties
+// it boils down to the question: does it have template support?
+type nondedupedContentGetter func(blockIndex int64) (content []byte, err error)
 
 // Set implements backendStorage.Set
 func (ss *nonDedupedStorage) Set(blockIndex int64, content []byte) (err error) {
@@ -51,13 +62,8 @@ func (ss *nonDedupedStorage) Set(blockIndex int64, content []byte) (err error) {
 
 // Merge implements backendStorage.Merge
 func (ss *nonDedupedStorage) Merge(blockIndex, offset int64, content []byte) (err error) {
-	conn, err := ss.provider.RedisConnection(blockIndex)
-	if err != nil {
-		return
-	}
-	defer conn.Close()
+	mergedContent, _ := ss.getContent(blockIndex)
 
-	mergedContent, _ := redis.Bytes(conn.Do("HGET", ss.vdiskID, blockIndex))
 	if ocl := int64(len(mergedContent)); ocl == 0 {
 		mergedContent = make([]byte, ss.blockSize)
 	} else if ocl < ss.blockSize {
@@ -69,6 +75,12 @@ func (ss *nonDedupedStorage) Merge(blockIndex, offset int64, content []byte) (er
 	// copy in new content
 	copy(mergedContent[offset:], content)
 
+	conn, err := ss.provider.RedisConnection(blockIndex)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
 	// store new content, as the merged version is non-zero
 	_, err = conn.Do("HSET", ss.vdiskID, blockIndex, mergedContent)
 	return
@@ -76,13 +88,7 @@ func (ss *nonDedupedStorage) Merge(blockIndex, offset int64, content []byte) (er
 
 // Get implements backendStorage.Get
 func (ss *nonDedupedStorage) Get(blockIndex int64) (content []byte, err error) {
-	conn, err := ss.provider.RedisConnection(blockIndex)
-	if err != nil {
-		return
-	}
-	defer conn.Close()
-
-	content, err = redisBytes(conn.Do("HGET", ss.vdiskID, blockIndex))
+	content, err = ss.getContent(blockIndex)
 	return
 }
 
@@ -109,6 +115,64 @@ func (ss *nonDedupedStorage) Close() error { return nil }
 
 // GoBackground implements backendStorage.GoBackground
 func (ss *nonDedupedStorage) GoBackground(context.Context) {}
+
+func (ss *nonDedupedStorage) getLocalContent(blockIndex int64) (content []byte, err error) {
+	conn, err := ss.provider.RedisConnection(blockIndex)
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	content, err = redisBytes(conn.Do("HGET", ss.vdiskID, blockIndex))
+	return
+}
+
+func (ss *nonDedupedStorage) getLocalOrRemoteContent(blockIndex int64) (content []byte, err error) {
+	content, err = ss.getLocalContent(blockIndex)
+	if err != nil || content != nil {
+		return // critical err, or content is found
+	}
+
+	content = func() (content []byte) {
+		conn, err := ss.provider.FallbackRedisConnection(blockIndex)
+		if err != nil {
+			log.Debugf(
+				"no local content available for block %d and no remote storage available: %s",
+				blockIndex, err.Error())
+			return
+		}
+		defer conn.Close()
+
+		content, err = redisBytes(conn.Do("HGET", ss.vdiskID, blockIndex))
+		if err != nil {
+			log.Debugf(
+				"content for block %d not available in local-, nor in remote storage: %s",
+				blockIndex, err.Error())
+			content = nil
+		}
+
+		return
+	}()
+
+	if content != nil {
+		// store remote content in local storage asynchronously
+		go func() {
+			err := ss.Set(blockIndex, content)
+			if err != nil {
+				// we won't return error however, but just log it
+				log.Infof(
+					"couldn't store remote content block %d in local storage: %s",
+					blockIndex, err.Error())
+			}
+		}()
+
+		log.Debugf(
+			"no local content block %d available, but did find remotely",
+			blockIndex)
+	}
+
+	return
+}
 
 // isZeroContent detects if a given content buffer is completely filled with 0s
 func (ss *nonDedupedStorage) isZeroContent(content []byte) bool {

--- a/nbdserver/ardb/nondeduped_test.go
+++ b/nbdserver/ardb/nondeduped_test.go
@@ -1,13 +1,63 @@
 package ardb
 
 import (
+	"bytes"
+	"crypto/rand"
+	"runtime/debug"
 	"testing"
+	"time"
 
+	"github.com/garyburd/redigo/redis"
+	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/redisstub"
 )
 
-func createTestNondedupedStorage(t *testing.T, vdiskID string, blockSize int64, provider *testRedisProvider) *nonDedupedStorage {
-	return newNonDedupedStorage(vdiskID, blockSize, provider).(*nonDedupedStorage)
+func createTestNondedupedStorage(t *testing.T, vdiskID string, blockSize int64, templateSupport bool, provider *testRedisProvider) *nonDedupedStorage {
+	return newNonDedupedStorage(vdiskID, blockSize, templateSupport, provider).(*nonDedupedStorage)
+}
+
+// testNondedupContentExists tests if
+// the given content exists in the database
+func testNondedupContentExists(t *testing.T, memRedis *redisstub.MemoryRedis, vdiskID string, blockIndex int64, content []byte) {
+	conn, err := memRedis.Dial("", 0)
+	if err != nil {
+		debug.PrintStack()
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	contentReceived, err := redis.Bytes(conn.Do("HGET", vdiskID, blockIndex))
+	if err != nil {
+		debug.PrintStack()
+		t.Fatal(err)
+	}
+	if bytes.Compare(content, contentReceived) != 0 {
+		debug.PrintStack()
+		t.Fatalf(
+			"content found (%v) does not equal content expected (%v)",
+			contentReceived, content)
+	}
+}
+
+// testNondedupContentDoesNotExist tests if
+// the given content does not exist in the database
+func testNondedupContentDoesNotExist(t *testing.T, memRedis *redisstub.MemoryRedis, vdiskID string, blockIndex int64, content []byte) {
+	conn, err := memRedis.Dial("", 0)
+	if err != nil {
+		debug.PrintStack()
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	contentReceived, err := redis.Bytes(conn.Do("HGET", vdiskID, blockIndex))
+
+	if err != nil || bytes.Compare(content, contentReceived) != 0 {
+		return
+	}
+
+	debug.PrintStack()
+	t.Fatalf(
+		"content found (%v), while it shouldn't exist", contentReceived)
 }
 
 func TestNondedupedContent(t *testing.T) {
@@ -20,7 +70,7 @@ func TestNondedupedContent(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestNondedupedStorage(t, vdiskID, 8, redisProvider)
+	storage := createTestNondedupedStorage(t, vdiskID, 8, false, redisProvider)
 	if storage == nil {
 		t.Fatal("storage is nil")
 	}
@@ -38,7 +88,7 @@ func TestNondedupedContentForceFlush(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestNondedupedStorage(t, vdiskID, 8, redisProvider)
+	storage := createTestNondedupedStorage(t, vdiskID, 8, false, redisProvider)
 	if storage == nil {
 		t.Fatal("storage is nil")
 	}
@@ -59,10 +109,204 @@ func TestNonDedupedDeadlock(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestNondedupedStorage(t, vdiskID, blockSize, redisProvider)
+	storage := createTestNondedupedStorage(t, vdiskID, blockSize, false, redisProvider)
 	if storage == nil {
 		t.Fatal("storage is nil")
 	}
 
 	testBackendStorageDeadlock(t, blockSize, blockCount, storage)
+}
+
+// test if content linked to local (copied) data,
+// is available only on the remote (root) storage,
+// while not yet on the local storage
+// supported since: https://github.com/zero-os/0-Disk/issues/223
+func TestGetNondedupedRootContent(t *testing.T) {
+	// create storageA
+	memRedisA := redisstub.NewMemoryRedis()
+	go memRedisA.Listen()
+	defer memRedisA.Close()
+
+	const (
+		vdiskID = "a"
+	)
+
+	redisProviderA := newTestRedisProvider(memRedisA, nil) // root = nil, later will be non-nil
+	storageA := createTestNondedupedStorage(t, vdiskID, 8, true, redisProviderA)
+	if storageA == nil {
+		t.Fatal("storageA is nil")
+	}
+
+	// create storageB, with storageA as its fallback/root
+	memRedisB := redisstub.NewMemoryRedis()
+	go memRedisB.Listen()
+	defer memRedisB.Close()
+
+	redisProviderB := newTestRedisProvider(memRedisB, memRedisA) // root = memRedisA
+	storageB := createTestNondedupedStorage(t, vdiskID, 8, true, redisProviderB)
+	if storageB == nil {
+		t.Fatal("storageB is nil")
+	}
+
+	testContent := []byte{4, 2}
+
+	var testBlockIndex int64 // 0
+
+	// content shouldn't exist in either of the 2 volumes
+	testNondedupContentDoesNotExist(t, memRedisA, vdiskID, testBlockIndex, testContent)
+	testNondedupContentDoesNotExist(t, memRedisB, vdiskID, testBlockIndex, testContent)
+
+	// store content in storageA
+	err := storageA.Set(testBlockIndex, testContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// content should now exist in storageA, but not yet in storageB
+	testNondedupContentExists(t, memRedisA, vdiskID, testBlockIndex, testContent)
+	testNondedupContentDoesNotExist(t, memRedisB, vdiskID, testBlockIndex, testContent)
+
+	// getting content from storageA should be possible
+	content, err := storageA.Get(testBlockIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content == nil {
+		t.Fatal("content should exist, while received nil-content")
+	}
+
+	// getting the content now should work
+	content, err = storageB.Get(testBlockIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content == nil {
+		t.Fatal("content should exist now, while received nil-content")
+	}
+
+	// content should now be in both storages
+	// as the remote get should have also stored the content locally
+	testNondedupContentExists(t, memRedisA, vdiskID, testBlockIndex, testContent)
+
+	// wait until the Get method saves the content async
+	time.Sleep(time.Millisecond * 200)
+	testNondedupContentExists(t, memRedisB, vdiskID, testBlockIndex, testContent)
+
+	// let's store some new content in storageB
+	testContent = []byte{9, 2}
+	testBlockIndex++
+
+	err = storageB.Set(testBlockIndex, testContent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// content should now exist in storageB, but not yet in storageA
+	testNondedupContentExists(t, memRedisB, vdiskID, testBlockIndex, testContent)
+	testNondedupContentDoesNotExist(t, memRedisA, vdiskID, testBlockIndex, testContent)
+
+	// let's now try to get it from storageA
+	// this should fail (manifested as nil-content), as storageA has no root,
+	// and the content isn't available locally
+	content, err = storageA.Get(testBlockIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content != nil {
+		t.Fatalf("content shouldn't exist now, while received: %v", content)
+	}
+
+	// we can however get the content from storageB
+	content, err = storageB.Get(testBlockIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content == nil {
+		t.Fatal("content should exist now, while received nil-content")
+	}
+
+	// and we can also do our direct test to ensure the content
+	// only exists in storageB
+	testNondedupContentExists(t, memRedisB, vdiskID, testBlockIndex, testContent)
+	testNondedupContentDoesNotExist(t, memRedisA, vdiskID, testBlockIndex, testContent)
+
+	// if we now make sure storageA, has storageB as its root,
+	// our previous Get attempt /will/ work
+	redisProviderA.rootMemRedis = memRedisB
+
+	content, err = storageA.Get(testBlockIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if content == nil {
+		t.Fatal("content should exist now, while received nil-content")
+	}
+
+	// and also our direct test should show that
+	// the content now exists in both storages
+	testNondedupContentExists(t, memRedisB, vdiskID, testBlockIndex, testContent)
+
+	// wait until the Get method saves the content async
+	time.Sleep(time.Millisecond * 200)
+	testNondedupContentExists(t, memRedisA, vdiskID, testBlockIndex, testContent)
+}
+
+func TestGetNondedupedRootContentDeadlock(t *testing.T) {
+	// create storageA
+	memRedisA := redisstub.NewMemoryRedis()
+	go memRedisA.Listen()
+	defer memRedisA.Close()
+
+	const (
+		vdiskID    = "a"
+		blockSize  = 128
+		blockCount = 256
+	)
+
+	var (
+		err error
+	)
+
+	redisProviderA := newTestRedisProvider(memRedisA, nil) // root = nil, later will be non-nil
+	storageA := createTestNondedupedStorage(t, vdiskID, blockSize, false, redisProviderA)
+	if storageA == nil {
+		t.Fatal("storageA is nil")
+	}
+
+	// create storageB, with storageA as its fallback/root
+	memRedisB := redisstub.NewMemoryRedis()
+	go memRedisB.Listen()
+	defer memRedisB.Close()
+
+	redisProviderB := newTestRedisProvider(memRedisB, memRedisA) // root = memRedisA
+	storageB := createTestNondedupedStorage(t, vdiskID, blockSize, true, redisProviderB)
+	if storageB == nil {
+		t.Fatal("storageB is nil")
+	}
+
+	var contentArray [blockCount][]byte
+
+	// store a lot of content in storageA
+	for i := int64(0); i < blockCount; i++ {
+		contentArray[i] = make([]byte, blockSize)
+		rand.Read(contentArray[i])
+		err = storageA.Set(i, contentArray[i])
+		if err != nil {
+			t.Fatal(i, err)
+		}
+	}
+
+	// now restore all content
+	// which will test the deadlock of async restoring
+	for i := int64(0); i < blockCount; i++ {
+		content, err := storageB.Get(i)
+		if err != nil {
+			t.Fatal(i, err)
+		}
+		if bytes.Compare(contentArray[i], content) != 0 {
+			t.Fatal(i, "unexpected content")
+		}
+	}
+}
+
+func init() {
+	log.SetLevel(log.DebugLevel)
 }

--- a/nbdserver/ardb/tlog_test.go
+++ b/nbdserver/ardb/tlog_test.go
@@ -72,7 +72,7 @@ func TestTlogStorageWithDeduped(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestDedupedStorage(t, vdiskID, blockSize, blockCount, redisProvider)
+	storage := createTestDedupedStorage(t, vdiskID, blockSize, blockCount, false, redisProvider)
 	if !assert.NotNil(t, storage) {
 		return
 	}
@@ -96,7 +96,7 @@ func TestTlogStorageForceFlushWithDeduped(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestDedupedStorage(t, vdiskID, blockSize, blockCount, redisProvider)
+	storage := createTestDedupedStorage(t, vdiskID, blockSize, blockCount, false, redisProvider)
 	if !assert.NotNil(t, storage) {
 		return
 	}
@@ -120,7 +120,7 @@ func TestTlogStorageDeadlockWithDeduped(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestDedupedStorage(t, vdiskID, blockSize, blockCount, redisProvider)
+	storage := createTestDedupedStorage(t, vdiskID, blockSize, blockCount, false, redisProvider)
 	if !assert.NotNil(t, storage) {
 		return
 	}
@@ -143,7 +143,7 @@ func TestTlogStorageWithNondeduped(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestNondedupedStorage(t, vdiskID, blockSize, redisProvider)
+	storage := createTestNondedupedStorage(t, vdiskID, blockSize, false, redisProvider)
 	if !assert.NotNil(t, storage) {
 		return
 	}
@@ -166,7 +166,7 @@ func TestTlogStorageForceFlushWithNondeduped(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestNondedupedStorage(t, vdiskID, blockSize, redisProvider)
+	storage := createTestNondedupedStorage(t, vdiskID, blockSize, false, redisProvider)
 	if !assert.NotNil(t, storage) {
 		return
 	}
@@ -190,7 +190,7 @@ func TestTlogStorageDeadlockWithNondeduped(t *testing.T) {
 	)
 
 	redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
-	storage := createTestNondedupedStorage(t, vdiskID, blockSize, redisProvider)
+	storage := createTestNondedupedStorage(t, vdiskID, blockSize, false, redisProvider)
 	if !assert.NotNil(t, storage) {
 		return
 	}

--- a/storagecluster/cluster.go
+++ b/storagecluster/cluster.go
@@ -285,12 +285,13 @@ func (cc *ClusterClient) loadConfig() bool {
 		return false
 	}
 
-	// check vdiskType, and sure it's the same one as last time
-	if cc.vdiskType != config.VdiskTypeNil && cc.vdiskType != vdisk.Type {
+	// validate vdiskType, and make sure it's the same one as last time
+	if cc.vdiskType.Validate() == nil && cc.vdiskType != vdisk.Type {
 		cc.logger.Infof("wrong type for vdisk %q, expected %q, while received %q",
 			cc.vdiskID, cc.vdiskType, vdisk.Type)
 		return false
 	}
+
 	cc.vdiskType = vdisk.Type
 
 	if cc.storageClusterName != "" {


### PR DESCRIPTION
+ fix #236 : make db vdisk type redudant;
+ fix #223 : add template support for db vdisk type (including unit tests);
+ use bit-matrix as vdisk types, such that checking for properties is cheaper and more sensible;