### PR TITLE
Increase timeout for testrace to 8 minutes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
     - stage: test
       go: 1.8
       install: skip
-      script: TIMEOUT=5m make testrace
+      script: TIMEOUT=8m make testrace
     - stage: test
       go: 1.8
       install:


### PR DESCRIPTION
Fixes #252 

Increase the timeout for testrace because `-race` test flag make the test slower.

Timeout value also applies for all tests, not invidual test.
I wrote simple script to test this at https://github.com/zero-os/0-Disk/issues/252#issuecomment-306979033