### PR TITLE
Improve config and docs

### DIFF
--- a/config/hotreload_test.go
+++ b/config/hotreload_test.go
@@ -105,7 +105,7 @@ func TestHotReloader(t *testing.T) {
 	configPath := createTempFile(t)
 	writeTestConfig(t, configPath, "localhost:16379", "a", "b")
 
-	hr, err := NewHotReloader(configPath)
+	hr, err := NewHotReloader(configPath, NBDServer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,7 +182,7 @@ func TestHotReloader(t *testing.T) {
 
 func TestNopHotReloader(t *testing.T) {
 	// requires a valid path
-	_, err := NopHotReloader("foo")
+	_, err := NopHotReloader("foo", NBDServer)
 	if !assert.Error(t, err) {
 		return
 	}
@@ -191,7 +191,7 @@ func TestNopHotReloader(t *testing.T) {
 	writeTestConfig(t, configPath, "localhost:16379", "a", "b")
 
 	// a valid path, gives us a (static) NopHotReloader
-	hr, err := NopHotReloader(configPath)
+	hr, err := NopHotReloader(configPath, NBDServer)
 	if !assert.NoError(t, err) || !assert.NotNil(t, hr) {
 		return
 	}
@@ -249,11 +249,6 @@ func writeTestConfig(t *testing.T, path, scaddr string, vdiskids ...string) {
 	os.Remove(path)
 
 	err := ioutil.WriteFile(path, []byte(config.String()), os.ModePerm)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = ValidateConfigPath(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/docs/nbd/config.md
+++ b/docs/nbd/config.md
@@ -29,26 +29,6 @@ storageClusters: # A required map of storage clusters,
         db: 1                        # database is optional, 0 by default
     metadataStorage: # Required ONLY when used as the (Root)StorageCluster of a `boot` vdisk
       address: 192.168.58.147:2001 # Required connection (dial)string
-  tlogcluster: # required (string) ID of this (optional) storage cluster,
-               # you are free to name the cluster however you want
-    dataStorage: # A required array of connection (dial) strings, used to store data,
-                 # NOTE that storage clusters used for tlog purposes,
-                 #      require at least K+M servers, rather than just the normal minimum of 1,
-                 #      this is not validated by the config file loader,
-                 #      but will result in a tlogclient handshake error,
-                 #      in case there are insufficient (N < K+M) dataStorage servers listed
-                 # in this example K=2 and M=2, thus we require 4 servers,
-                 # extra servers (I >= K+M) are allowed, but ignored
-     - address: 192.168.58.148:2000 # Required connection (dial) string
-       db: 0                        # Database is optional, 0 by default
-     - address: 192.168.58.148:2000 # Required connection (dial) string
-       db: 1                        # Database is optional
-     - address: 192.168.58.148:2000 # Required connection (dial) string
-       db: 2                        # Database is optional
-     - address: 192.168.58.148:2000 # Required connection (dial) string
-       db: 3                        # Database is optional
-    metadataStorage: # Ignored when used ONLY as a tlogStorageCluster
-      address: 192.168.58.149:2000 # Required connection (dial) string
   # ... more (optional) storage clusters
 vdisks: # A required map of vdisks,
         # only 1 vdisk is required,
@@ -66,10 +46,6 @@ vdisks: # A required map of vdisks,
                                     # for this vdisk's fallback/root/template storage, has to be
                                     # a storage cluster defined in the `storageClusters` section
                                     # of THIS config file
-    tlogStorageCluster: tlogcluster # (String) ID of the tlog storage cluster to use
-                                    # for this vdisk's tlog's aggregation storage,
-                                    # NOTE that this property is REQUIRED in case
-                                    # you have a tlogserver connected to your nbdserver
     type: boot # Required (VdiskType) type of this vdisk
                # which also defines if its deduped or nondeduped,
                # valid types are: `boot`, `db`, `cache` and `tmp`

--- a/docs/tlog/config.md
+++ b/docs/tlog/config.md
@@ -1,6 +1,4 @@
-# Go Tlog Server
-
-## Tlog Server Configuration
+# Tlog Server Configuration
 
 The Tlog server is configured using a YAML configuration file:
 
@@ -38,60 +36,3 @@ vdisks: # A required map of vdisks,
 By default the `tlogserver` executable assumes the `config.yml` file
 exists within the working directory of its process. This location can be defined
 using the `--config path` optional CLI flag.
-
-### Live reloading of the configuration
-
-A running tlogserver in a production environment can not simply be restarted
-since this will break the connection to any connected client.
-When the configuration file is modified,
-send a `SIGHUP` signal to the tlogserver to make it pick up the changes.
-
-**NOTE**: It is not recommended to change the configs of storage clusters,
-whichare still in use by active (connected) clients,
-and content might get lost if you do this anyway.
-
-## Usage
-
-Use `tlogserver -h` or `tlogserver --help` to get more information about all available flags.
-
-## erasure coding
-
-It use [isa-l](https://github.com/01org/isa-l) C library and [templexxx/reedsolomon](https://github.com/templexxx/reedsolomon) Go library for erasure coding.
-
-Only one can be used at a time.
-
-By default, the erasure coding is done in go.
-
-When using the C isa-l library for the erasure coding, `-tags isal` needs be passed to go build.
-And `GODEBUG=cgocheck=0` environment variable need to be set in order to run it.
-
-
-**Build**
-
-From this repo root directory
-```
-make tlogserver
-```
-
-
-**Usage**
-
-Run it
-```
-./bin/tlogserver  -storage-addresses=127.0.0.1:16379 -k 16 -m 4
-```
-
-It starts tlog server that:
-- listen on default listen address 0.0.0.0:11211
-- need 16 data shards and 4 parity/coding shards -> total 20 ardb 
-- first ardb address is `127.0.0.1:16379`, the seconds is in same IP but in port `16380`, the third in port `16381`, and so on...
-
-To specify each ardb adddress, use array as address, example:`-storage-addresses=127.0.0.1:16379,127.0.0.1:16380,127.0.0.1:16381` to specify 3 ardbs
-
-Use tlog client as described in [client readme](../tlogclient/readme.md) to send transaction log to this tlog server.
-
-
-**benchmark**
-```
-GODEBUG=cgocheck=0 go test -tags isal -bench=.
-```

--- a/nbdserver/ardb/ardb.go
+++ b/nbdserver/ardb/ardb.go
@@ -240,11 +240,6 @@ func (rp *redisProvider) MetaRedisConnection() (conn redis.Conn, err error) {
 	rp.mux.RLock()
 	defer rp.mux.RUnlock()
 
-	if rp.metaConnectionConfig == nil {
-		err = errNoMetaAvailable
-		return
-	}
-
 	connConfig := rp.metaConnectionConfig
 	conn = rp.redisPool.Get(connConfig.Address, connConfig.Database)
 	return
@@ -309,6 +304,5 @@ func (rp *redisProvider) reloadConfig(cfg *config.VdiskClusterConfig) error {
 }
 
 var (
-	errNoMetaAvailable = errors.New("no meta ardb connection available")
 	errNoRootAvailable = errors.New("no root ardb connection available")
 )

--- a/nbdserver/main.go
+++ b/nbdserver/main.go
@@ -156,7 +156,7 @@ func main() {
 	redisPool := ardb.NewRedisPool(poolDial)
 	defer redisPool.Close()
 
-	configHotReloader, err := config.NewHotReloader(configPath)
+	configHotReloader, err := config.NewHotReloader(configPath, config.NBDServer)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tlog/redispool.go
+++ b/tlog/redispool.go
@@ -78,7 +78,7 @@ func StaticRedisPoolFactory(requiredDataServerCount int, storageServers []config
 // such that at creation of a RedisPool, it is validated that the
 // storage cluster in question has sufficient data servers available.
 func ConfigRedisPoolFactory(requiredDataServerCount int, configPath string) (RedisPoolFactory, error) {
-	reloader, err := config.NewHotReloader(configPath)
+	reloader, err := config.NewHotReloader(configPath, config.TlogServer)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't create RedisPoolFactory: %s", err.Error())
 	}
@@ -168,7 +168,7 @@ func InMemoryRedisPool(requiredDataServerCount int) RedisPool {
 // using the storage cluster defined in the given Blokstor config file,
 // for that vdisk.
 func RedisPoolFromConfig(configPath, vdiskID string, requiredDataServerCount int) (RedisPool, error) {
-	cfg, err := config.ReadConfig(configPath)
+	cfg, err := config.ReadConfig(configPath, config.TlogServer)
 	if err != nil {
 		return nil, err
 	}

--- a/zeroctl/cmd/copyvdisk/vdisk.go
+++ b/zeroctl/cmd/copyvdisk/vdisk.go
@@ -48,7 +48,7 @@ func copyVdisk(cmd *cobra.Command, args []string) error {
 
 	log.Infof("loading config %s...", vdiskCfg.ConfigPath)
 
-	cfg, err := config.ReadConfig(vdiskCfg.ConfigPath)
+	cfg, err := config.ReadConfig(vdiskCfg.ConfigPath, config.NBDServer)
 	if err != nil {
 		return err
 	}

--- a/zeroctl/cmd/delvdisk/vdisks.go
+++ b/zeroctl/cmd/delvdisk/vdisks.go
@@ -31,7 +31,7 @@ func deleteVdisks(cmd *cobra.Command, args []string) error {
 
 	log.Infof("loading config %s...", vdisksCfg.ConfigPath)
 
-	cfg, err := config.ReadConfig(vdisksCfg.ConfigPath)
+	cfg, err := config.ReadConfig(vdisksCfg.ConfigPath, config.NBDServer)
 	if err != nil {
 		return err
 	}

--- a/zeroctl/cmd/restore/vdisk.go
+++ b/zeroctl/cmd/restore/vdisk.go
@@ -88,7 +88,7 @@ func newBackend(ctx context.Context, dial ardb.DialFunc, tlogrpc, vdiskID, confi
 	// redis pool
 	redisPool := ardb.NewRedisPool(dial)
 
-	hotreloader, err := zerodiskcfg.NopHotReloader(configPath)
+	hotreloader, err := zerodiskcfg.NopHotReloader(configPath, zerodiskcfg.NBDServer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
+ make tlog/nbd config more flexible: the zerodisk configuration is now more flexible,
and validates the config based on the use case (nbdserver or/and tlogserver);
+ improve/add config (nbd/tlog) readme docs (fixes #259);