### PR TITLE
Make the tlogclient's blockbuffer scalable.

### DIFF
--- a/tlog/tlogclient/blockbuffer/entry.go
+++ b/tlog/tlogclient/blockbuffer/entry.go
@@ -10,7 +10,7 @@ import (
 type entry struct {
 	block    *schema.TlogBlock
 	retryNum int
-	timeout  time.Time
+	timeout  int64
 }
 
 // newEntry creates a new buffer Entry
@@ -18,20 +18,20 @@ func newEntry(block *schema.TlogBlock, timeoutDur time.Duration) *entry {
 	return &entry{
 		block:    block,
 		retryNum: 0,
-		timeout:  time.Now().Add(timeoutDur),
+		timeout:  time.Now().Add(timeoutDur).UnixNano(),
 	}
 }
 
 // update states of this entry
 func (ent *entry) update(timeoutDur time.Duration, retryInc int) {
 	ent.retryNum += retryInc
-	ent.timeout = time.Now().Add(timeoutDur)
+	ent.timeout = time.Now().Add(timeoutDur).UnixNano()
 }
 
 func (ent *entry) isTimeout(now time.Time) bool {
-	return ent.timeout.Sub(now) <= 0
+	return ent.timeout-now.UnixNano() <= 0
 }
 
 func (ent *entry) setTimeout() {
-	ent.timeout = time.Now()
+	ent.timeout = time.Now().UnixNano()
 }

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -121,11 +121,12 @@ func (c *Client) connect(firstSequence uint64, resetFirstSeq bool) (err error) {
 
 // goroutine which re-send the block.
 func (c *Client) resender() {
+	timeoutCh := c.blockBuffer.TimedOut(c.ctx)
 	for {
 		select {
 		case <-c.ctx.Done():
 			return
-		case block := <-c.blockBuffer.TimedOut():
+		case block := <-timeoutCh:
 			data, err := block.Data()
 			if err != nil {
 				log.Errorf("client resender failed to get data block:%v", err)


### PR DESCRIPTION
Closes #250 

In previous version, it scans the whole Go map to find the timed out blocks.
In this version, it added an array of sequence numbers ordered by it's timeout.
Which can be used by blockbuffer to find the timed out blocks without scanning the whole map.