### PR TITLE
nbdserver : failover to slave.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -335,15 +335,16 @@ type StorageServerConfig struct {
 
 // VdiskConfig defines the config for a vdisk
 type VdiskConfig struct {
-	BlockSize          uint64    `yaml:"blockSize" valid:"optional"`
-	ReadOnly           bool      `yaml:"readOnly" valid:"optional"`
-	Size               uint64    `yaml:"size" valid:"optional"`
-	StorageCluster     string    `yaml:"storageCluster" valid:"optional"`
-	RootStorageCluster string    `yaml:"rootStorageCluster" valid:"optional"`
-	RootVdiskID        string    `yaml:"rootVdiskID" valid:"optional"`
-	TlogStorageCluster string    `yaml:"tlogStorageCluster" valid:"optional"`
-	TlogSlaveSync      bool      `yaml:"tlogSlaveSync" valid:"optional"` // true if tlog need to sync ardb slave
-	Type               VdiskType `yaml:"type" valid:"optional"`
+	BlockSize           uint64    `yaml:"blockSize" valid:"optional"`
+	ReadOnly            bool      `yaml:"readOnly" valid:"optional"`
+	Size                uint64    `yaml:"size" valid:"optional"`
+	StorageCluster      string    `yaml:"storageCluster" valid:"optional"`
+	SlaveStorageCluster string    `yaml:"slaveStorageCluster" valid:"optional"`
+	RootStorageCluster  string    `yaml:"rootStorageCluster" valid:"optional"`
+	RootVdiskID         string    `yaml:"rootVdiskID" valid:"optional"`
+	TlogStorageCluster  string    `yaml:"tlogStorageCluster" valid:"optional"`
+	TlogSlaveSync       bool      `yaml:"tlogSlaveSync" valid:"optional"` // true if tlog need to sync ardb slave
+	Type                VdiskType `yaml:"type" valid:"optional"`
 }
 
 // StorageType returns the type of storage this vdisk uses

--- a/nbdserver/ardb/ardb.go
+++ b/nbdserver/ardb/ardb.go
@@ -31,6 +31,7 @@ type BackendFactoryConfig struct {
 	TLogRPCAddress           string
 	RootARDBConnectionString string
 	LBACacheLimit            int64 // min-capped to LBA.BytesPerShard
+	ConfigPath               string
 }
 
 // Validate all the parameters of this BackendFactoryConfig
@@ -58,6 +59,7 @@ func NewBackendFactory(cfg BackendFactoryConfig) (*BackendFactory, error) {
 		cfgHotReloader: cfg.ConfigHotReloader,
 		tlogRPCAddress: cfg.TLogRPCAddress,
 		lbaCacheLimit:  cfg.LBACacheLimit,
+		configPath:     cfg.ConfigPath,
 	}, nil
 }
 
@@ -69,6 +71,7 @@ type BackendFactory struct {
 	cfgHotReloader config.HotReloader
 	tlogRPCAddress string
 	lbaCacheLimit  int64
+	configPath     string
 }
 
 //NewBackend generates a new ardb backend
@@ -135,7 +138,7 @@ func (f *BackendFactory) NewBackend(ctx context.Context, ec *nbd.ExportConfig) (
 
 	if vdisk.TlogSupport() && f.tlogRPCAddress != "" {
 		log.Debugf("creating tlogStorage for backend %v (%v)", vdiskID, vdisk.Type)
-		storage, err = newTlogStorage(vdiskID, f.tlogRPCAddress, blockSize, storage)
+		storage, err = newTlogStorage(vdiskID, f.tlogRPCAddress, f.configPath, blockSize, storage)
 		if err != nil {
 			log.Infof("couldn't create tlog storage: %s", err.Error())
 			return

--- a/nbdserver/ardb/tlog.go
+++ b/nbdserver/ardb/tlog.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"math"
+	"os"
 	"sync"
+	"syscall"
 	"time"
 
+	"github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/tlog"
 	"github.com/zero-os/0-Disk/tlog/schema"
@@ -19,16 +23,16 @@ const (
 	tlogFlushWait = 10 * time.Second
 )
 
-func newTlogStorage(vdiskID, tlogrpc string, blockSize int64, storage backendStorage) (backendStorage, error) {
+func newTlogStorage(vdiskID, tlogrpc, configPath string, blockSize int64, storage backendStorage) (backendStorage, error) {
 	client, err := tlogclient.New(tlogrpc, vdiskID, 0, true)
 	if err != nil {
 		return nil, fmt.Errorf("tlogStorage requires a valid tlogclient: %s", err.Error())
 	}
 
-	return newTlogStorageWithClient(vdiskID, blockSize, client, storage)
+	return newTlogStorageWithClient(vdiskID, configPath, blockSize, client, storage)
 }
 
-func newTlogStorageWithClient(vdiskID string, blockSize int64, client tlogClient, storage backendStorage) (backendStorage, error) {
+func newTlogStorageWithClient(vdiskID, configPath string, blockSize int64, client tlogClient, storage backendStorage) (backendStorage, error) {
 	if storage == nil {
 		return nil, errors.New("tlogStorage requires a non-nil storage")
 	}
@@ -43,6 +47,7 @@ func newTlogStorageWithClient(vdiskID string, blockSize int64, client tlogClient
 		transactionCh:  make(chan *transaction, transactionChCapacity),
 		toFlushCh:      make(chan []uint64, toFlushChCapacity),
 		cacheEmptyCond: sync.NewCond(&sync.Mutex{}),
+		configPath:     configPath,
 	}, nil
 }
 
@@ -63,6 +68,8 @@ type tlogStorage struct {
 
 	// condition variable used to signal when the cache is empty
 	cacheEmptyCond *sync.Cond
+
+	configPath string
 }
 
 type transaction struct {
@@ -361,6 +368,67 @@ func (tls *tlogStorage) flusher(ctx context.Context) {
 
 }
 
+// switch to ardb slave if possible
+func (tls *tlogStorage) switchToArdbSlave() error {
+	if tls.configPath == "" {
+		return fmt.Errorf("no config found")
+	}
+
+	// get config file permission
+	// we need it because we want to rewrite it.
+	// better to write it with same permission
+	filePerm, err := func() (os.FileMode, error) {
+		info, err := os.Stat(tls.configPath)
+		if err != nil {
+			return 0, err
+		}
+		return info.Mode(), nil
+	}()
+	if err != nil {
+		return err
+	}
+
+	// parse the config
+	conf, err := config.ReadConfig(tls.configPath, config.NBDServer)
+	if err != nil {
+		return err
+	}
+
+	vdiskConf, exist := conf.Vdisks[tls.vdiskID]
+	if !exist {
+		return fmt.Errorf("no config found for vdisk: %v", tls.vdiskID)
+	}
+
+	if vdiskConf.SlaveStorageCluster == "" {
+		return fmt.Errorf("vdisk %v doesn't have ardb slave", tls.vdiskID)
+	}
+
+	// switch to slave (still in config only)
+	vdiskConf.StorageCluster = vdiskConf.SlaveStorageCluster
+	vdiskConf.SlaveStorageCluster = ""
+	conf.Vdisks[tls.vdiskID] = vdiskConf
+
+	// ask tlog to sync the slave
+	if err := tls.tlog.WaitNbdSlaveSync(); err != nil {
+		return err
+	}
+
+	// rewrite the config
+	if err := ioutil.WriteFile(tls.configPath, []byte(conf.String()), filePerm); err != nil {
+		return err
+	}
+
+	// reload the config
+	syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+
+	// give some time for the reloader to work
+	// TODO : give access to the reloader, so we don't need to do some random sleep
+	time.Sleep(1 * time.Second)
+
+	// TODO : notify the orchestrator or ays or any other interested parties
+	return nil
+}
+
 func (tls *tlogStorage) flushCachedContent(sequences []uint64) error {
 	defer func() {
 		tls.cacheEmptyCond.L.Lock()
@@ -381,14 +449,7 @@ func (tls *tlogStorage) flushCachedContent(sequences []uint64) error {
 
 	var errs flushErrors
 	for blockIndex, data := range elements {
-		var err error
-
-		if data == nil {
-			err = tls.storage.Delete(blockIndex)
-		} else {
-			err = tls.storage.Set(blockIndex, data)
-		}
-
+		err := tls.flushAContent(blockIndex, data)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -399,6 +460,22 @@ func (tls *tlogStorage) flushCachedContent(sequences []uint64) error {
 	}
 
 	return nil
+}
+
+func (tls *tlogStorage) flushAContent(blockIndex int64, data []byte) error {
+	flush := func() error {
+		if data == nil {
+			return tls.storage.Delete(blockIndex)
+		}
+		return tls.storage.Set(blockIndex, data)
+	}
+	if err := flush(); err == nil {
+		return nil
+	}
+	if err := tls.switchToArdbSlave(); err != nil {
+		return err
+	}
+	return flush()
 }
 
 type flushErrors []error
@@ -471,6 +548,7 @@ func (tls *tlogStorage) getLatestSequence() (sequence uint64) {
 type tlogClient interface {
 	Send(op uint8, seq, offset, timestamp uint64, data []byte, size uint64) error
 	ForceFlushAtSeq(uint64) error
+	WaitNbdSlaveSync() error
 	Recv() <-chan *tlogclient.Result
 	Close() error
 }

--- a/nbdserver/ardb/tlog_gap_test.go
+++ b/nbdserver/ardb/tlog_gap_test.go
@@ -35,7 +35,7 @@ func TestTlogStorageSlow(t *testing.T) {
 		return
 	}
 
-	storage, err := newTlogStorage(vdiskID, tlogrpc, blockSize, slowStorage)
+	storage, err := newTlogStorage(vdiskID, tlogrpc, "", blockSize, slowStorage)
 	if !assert.NoError(t, err) || !assert.NotNil(t, storage) {
 		return
 	}

--- a/nbdserver/ardb/tlog_test.go
+++ b/nbdserver/ardb/tlog_test.go
@@ -204,7 +204,7 @@ func testTlogStorage(t *testing.T, vdiskID string, blockSize int64, storage back
 		return
 	}
 
-	storage, err := newTlogStorage(vdiskID, tlogrpc, blockSize, storage)
+	storage, err := newTlogStorage(vdiskID, tlogrpc, "", blockSize, storage)
 	if !assert.NoError(t, err) || !assert.NotNil(t, storage) {
 		return
 	}
@@ -218,7 +218,7 @@ func testTlogStorageForceFlush(t *testing.T, vdiskID string, blockSize int64, st
 		return
 	}
 
-	storage, err := newTlogStorage(vdiskID, tlogrpc, blockSize, storage)
+	storage, err := newTlogStorage(vdiskID, tlogrpc, "", blockSize, storage)
 	if !assert.NoError(t, err) || !assert.NotNil(t, storage) {
 		return
 	}
@@ -232,7 +232,7 @@ func testTlogStorageDeadlock(t *testing.T, vdiskID string, blockSize, blockCount
 		return
 	}
 
-	storage, err := newTlogStorage(vdiskID, tlogrpc, blockSize, storage)
+	storage, err := newTlogStorage(vdiskID, tlogrpc, "", blockSize, storage)
 	if !assert.NoError(t, err) || !assert.NotNil(t, storage) {
 		return
 	}

--- a/nbdserver/main.go
+++ b/nbdserver/main.go
@@ -159,6 +159,7 @@ func main() {
 		ConfigHotReloader: configHotReloader,
 		TLogRPCAddress:    tlogrpcaddress,
 		LBACacheLimit:     lbacachelimit,
+		ConfigPath:        configPath,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/nbdserver/readme.md
+++ b/nbdserver/readme.md
@@ -36,6 +36,10 @@ vdisks: # A required map of vdisks,
     storageCluster: mycluster # Required (string) ID of the storage cluster to use
                               # for this vdisk's storage, has to be a storage cluster
                               # defined in the `storageClusters` section of THIS config file
+
+    slaveStorageCluster: slaveCluster # Optional (string) ID of the storage cluster to use
+                                      # for this vdisk's storage, has to be a storage cluster
+                                      # defined in the `storageClusters` section of THIS config file
     rootStorageCluster: rootcluster # Optional (string) ID of the (root) storage cluster to use
                                     # for this vdisk's fallback/root/template storage, has to be
                                     # a storage cluster defined in the `storageClusters` section

--- a/tlog/tlogserver/README.md
+++ b/tlog/tlogserver/README.md
@@ -25,6 +25,13 @@ storageClusters: # A required map of storage clusters
      - address: 192.168.58.148:2000 # Required connection (dial) string
        db: 3                        # Database is optional
   # ... more (optional) storage clusters
+
+  nbdSlaveCluster: # ID of this storage cluster
+    dataStorage: # A required array of connection (dial)strings, used to store data
+      - address: 127.0.0.1:16386 # At least 1 connection (dial)string is required,
+    metadataStorage:
+      address: 127.0.0.1:16387 # Required connection (dial)string,
+
 vdisks: # A required map of vdisks,
         # only 1 vdisk is required
   myvdisk: # Required (string) ID of this vdisk
@@ -34,6 +41,10 @@ vdisks: # A required map of vdisks,
                                     # you have a tlogserver connected to your nbdserver
     tlogSlaveSync: true # true if tlog need to sync ardb slave,
                         # optional and false by default
+    storageCluster: nbdSlaveCluster # Required if `tlogSlaveSync` is true.
+                                    # ID of the nbdserver slave storage cluster
+                                    # has to be a storage cluster
+                                    # defined in the `storageClusters` section of THIS config file
   # ... more (optional) vdisks
 ```
 
@@ -51,6 +62,22 @@ send a `SIGHUP` signal to the tlogserver to make it pick up the changes.
 **NOTE**: It is not recommended to change the configs of storage clusters,
 whichare still in use by active (connected) clients,
 and content might get lost if you do this anyway.
+
+### Nbdserver slave sync feature
+
+Tlog server has feature to sync all nbdserver operation to the ardb slave.
+In case nbdserver's master failed, nbdserver can switch to this slave.
+
+This feature need this configuration:
+- set tlogserver command line `-with-slave-sync` to true. It is false by default
+- set `tlogSlaveSync` in vdisk configuration to true. See the example above
+- set `storageCluster` to the slave's cluster. See the example above
+
+After nbdserver switch to slave (internally by executing `WaitNbdSlaveSync` command),
+the slave sync feature of this vdisk become disabled.
+To re-enable this, the vdisk need to be restarted in nbdserver side.
+
+TODO : when hot reload the config, re-enable the slave sync if possible.
 
 ## Usage
 

--- a/tlog/tlogserver/server/vdisk.go
+++ b/tlog/tlogserver/server/vdisk.go
@@ -197,7 +197,12 @@ func (vd *vdisk) waitSlaveSync() error {
 	// wait and return the response
 	err := <-cmd.respCh
 	if err == nil {
-		vd.withSlaveSyncer = false // TODO : reload the slave config
+		// we've successfully synced the slave
+		// it means the slave is going to be used by nbdserver as it's master
+		// so we disable it and kill the slave syncer
+		vd.withSlaveSyncer = false
+		vd.aggComm.Destroy()
+		vd.aggComm = nil
 	}
 
 	return err


### PR DESCRIPTION
Fixes #276 as part of #38 

It adds support for ndbserver to switch to ardb slave in case of failing ardb master.

Note that this PR  only deals with nbdserver part.
The tlogserver and client already partially done in previous PRs.

Summary of changes:
- Add `SlaveStorageCluster` to the `0-Disk/config.Config`
- add ConfigPath to the nbd backend factory and tlogStorage
  We need it in order to tlogStorage be able to rewrite the config
- in case of ardb/storage operation failed, it do these:
	- make sure we have slave storage cluster
	- wait for slave to be fully synced by tlog
	- override the config, set the slave as master
	- hot reload the config

Limitations:
- ~~the failing detection currently only happens at `flushCachedContent`, other places could be added easily~~ It doesn't retry or reconnect in case of failed ardb operation, because i think it should be done by storage module
- it needs to wait for the hot reload to be finished, it currently do this by sleeping for 1 second, let me know if there is better way to do this
- orchestrator part is not included in this PR
- ~~test code is super mess~~