### PR TITLE
Reliable slave sync

### DIFF
--- a/nbdserver/ardb/tlog_gap_test.go
+++ b/nbdserver/ardb/tlog_gap_test.go
@@ -20,6 +20,9 @@ func TestTlogStorageSlow(t *testing.T) {
 		blockCount = 512
 	)
 
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const sleepTime = time.Millisecond * 25
 
 	slowStorage := &slowInMemoryStorage{
@@ -30,7 +33,7 @@ func TestTlogStorageSlow(t *testing.T) {
 		return
 	}
 
-	tlogrpc := newTlogTestServer(t)
+	tlogrpc := newTlogTestServer(ctx, t)
 	if !assert.NotEmpty(t, tlogrpc) {
 		return
 	}
@@ -39,9 +42,6 @@ func TestTlogStorageSlow(t *testing.T) {
 	if !assert.NoError(t, err) || !assert.NotNil(t, storage) {
 		return
 	}
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
 	go storage.GoBackground(ctx)
 	defer storage.Close()
 

--- a/nbdserver/ardb/tlog_test.go
+++ b/nbdserver/ardb/tlog_test.go
@@ -2,6 +2,7 @@ package ardb
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"sync"
 	"testing"
@@ -14,6 +15,9 @@ import (
 )
 
 func TestTlogStorageWithInMemory(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const (
 		vdiskID   = "a"
 		blockSize = 8
@@ -24,10 +28,12 @@ func TestTlogStorageWithInMemory(t *testing.T) {
 		return
 	}
 
-	testTlogStorage(t, vdiskID, blockSize, storage)
+	testTlogStorage(ctx, t, vdiskID, blockSize, storage)
 }
 
 func TestTlogStorageForceFlushWithInMemory(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
 	const (
 		vdiskID   = "a"
 		blockSize = 8
@@ -38,10 +44,13 @@ func TestTlogStorageForceFlushWithInMemory(t *testing.T) {
 		return
 	}
 
-	testTlogStorageForceFlush(t, vdiskID, blockSize, storage)
+	testTlogStorageForceFlush(ctx, t, vdiskID, blockSize, storage)
 }
 
 func TestTlogStorageWithInMemoryDeadlock(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const (
 		vdiskID    = "a"
 		blockSize  = 128
@@ -53,10 +62,13 @@ func TestTlogStorageWithInMemoryDeadlock(t *testing.T) {
 		return
 	}
 
-	testTlogStorageDeadlock(t, vdiskID, blockSize, blockCount, storage)
+	testTlogStorageDeadlock(ctx, t, vdiskID, blockSize, blockCount, storage)
 }
 
 func TestTlogStorageWithDeduped(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	memRedis := redisstub.NewMemoryRedis()
 	if !assert.NotNil(t, memRedis) {
 		return
@@ -77,10 +89,13 @@ func TestTlogStorageWithDeduped(t *testing.T) {
 		return
 	}
 
-	testTlogStorage(t, vdiskID, blockSize, storage)
+	testTlogStorage(ctx, t, vdiskID, blockSize, storage)
 }
 
 func TestTlogStorageForceFlushWithDeduped(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	memRedis := redisstub.NewMemoryRedis()
 	if !assert.NotNil(t, memRedis) {
 		return
@@ -101,10 +116,13 @@ func TestTlogStorageForceFlushWithDeduped(t *testing.T) {
 		return
 	}
 
-	testTlogStorageForceFlush(t, vdiskID, blockSize, storage)
+	testTlogStorageForceFlush(ctx, t, vdiskID, blockSize, storage)
 }
 
 func TestTlogStorageDeadlockWithDeduped(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	memRedis := redisstub.NewMemoryRedis()
 	if !assert.NotNil(t, memRedis) {
 		return
@@ -125,10 +143,13 @@ func TestTlogStorageDeadlockWithDeduped(t *testing.T) {
 		return
 	}
 
-	testTlogStorageDeadlock(t, vdiskID, blockSize, blockCount, storage)
+	testTlogStorageDeadlock(ctx, t, vdiskID, blockSize, blockCount, storage)
 }
 
 func TestTlogStorageWithNondeduped(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	memRedis := redisstub.NewMemoryRedis()
 	if !assert.NotNil(t, memRedis) {
 		return
@@ -148,10 +169,13 @@ func TestTlogStorageWithNondeduped(t *testing.T) {
 		return
 	}
 
-	testTlogStorage(t, vdiskID, blockSize, storage)
+	testTlogStorage(ctx, t, vdiskID, blockSize, storage)
 }
 
 func TestTlogStorageForceFlushWithNondeduped(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	memRedis := redisstub.NewMemoryRedis()
 	if !assert.NotNil(t, memRedis) {
 		return
@@ -171,10 +195,13 @@ func TestTlogStorageForceFlushWithNondeduped(t *testing.T) {
 		return
 	}
 
-	testTlogStorageForceFlush(t, vdiskID, blockSize, storage)
+	testTlogStorageForceFlush(ctx, t, vdiskID, blockSize, storage)
 }
 
 func TestTlogStorageDeadlockWithNondeduped(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	memRedis := redisstub.NewMemoryRedis()
 	if !assert.NotNil(t, memRedis) {
 		return
@@ -195,11 +222,11 @@ func TestTlogStorageDeadlockWithNondeduped(t *testing.T) {
 		return
 	}
 
-	testTlogStorageDeadlock(t, vdiskID, blockSize, blockCount, storage)
+	testTlogStorageDeadlock(ctx, t, vdiskID, blockSize, blockCount, storage)
 }
 
-func testTlogStorage(t *testing.T, vdiskID string, blockSize int64, storage backendStorage) {
-	tlogrpc := newTlogTestServer(t)
+func testTlogStorage(ctx context.Context, t *testing.T, vdiskID string, blockSize int64, storage backendStorage) {
+	tlogrpc := newTlogTestServer(ctx, t)
 	if !assert.NotEmpty(t, tlogrpc) {
 		return
 	}
@@ -212,8 +239,8 @@ func testTlogStorage(t *testing.T, vdiskID string, blockSize int64, storage back
 	testBackendStorage(t, storage)
 }
 
-func testTlogStorageForceFlush(t *testing.T, vdiskID string, blockSize int64, storage backendStorage) {
-	tlogrpc := newTlogTestServer(t)
+func testTlogStorageForceFlush(ctx context.Context, t *testing.T, vdiskID string, blockSize int64, storage backendStorage) {
+	tlogrpc := newTlogTestServer(ctx, t)
 	if !assert.NotEmpty(t, tlogrpc) {
 		return
 	}
@@ -226,8 +253,8 @@ func testTlogStorageForceFlush(t *testing.T, vdiskID string, blockSize int64, st
 	testBackendStorageForceFlush(t, storage)
 }
 
-func testTlogStorageDeadlock(t *testing.T, vdiskID string, blockSize, blockCount int64, storage backendStorage) {
-	tlogrpc := newTlogTestServer(t)
+func testTlogStorageDeadlock(ctx context.Context, t *testing.T, vdiskID string, blockSize, blockCount int64, storage backendStorage) {
+	tlogrpc := newTlogTestServer(ctx, t)
 	if !assert.NotEmpty(t, tlogrpc) {
 		return
 	}
@@ -240,7 +267,7 @@ func testTlogStorageDeadlock(t *testing.T, vdiskID string, blockSize, blockCount
 	testBackendStorageDeadlock(t, blockSize, blockCount, storage)
 }
 
-func newTlogTestServer(t *testing.T) string {
+func newTlogTestServer(ctx context.Context, t *testing.T) string {
 	testConf := &server.Config{
 		K:          4,
 		M:          2,
@@ -262,7 +289,7 @@ func newTlogTestServer(t *testing.T) string {
 	if !assert.NoError(t, err) {
 		return ""
 	}
-	go s.Listen()
+	go s.Listen(ctx)
 
 	return s.ListenAddr()
 }

--- a/nbdserver/main.go
+++ b/nbdserver/main.go
@@ -83,6 +83,7 @@ func main() {
 		}()
 	}
 
+	ctx, cancelFunc := context.WithCancel(context.Background())
 	// create embedded tlog api if needed
 	if tlogrpcaddress == "auto" {
 		log.Info("Starting embedded (in-memory) tlogserver")
@@ -111,7 +112,7 @@ func main() {
 		tlogrpcaddress = server.ListenAddr()
 
 		log.Debug("embedded (in-memory) tlogserver up and running")
-		go server.Listen()
+		go server.Listen(ctx)
 	}
 	if tlogrpcaddress != "" {
 		log.Info("Using tlog rpc at", tlogrpcaddress)
@@ -119,7 +120,6 @@ func main() {
 
 	var sessionWaitGroup sync.WaitGroup
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
 	configCtx, configCancelFunc := context.WithCancel(ctx)
 	defer func() {
 		log.Info("Shutting down")

--- a/tlog/tlogclient/decoder/limiter.go
+++ b/tlog/tlogclient/decoder/limiter.go
@@ -1,0 +1,115 @@
+package decoder
+
+import (
+	"github.com/zero-os/0-Disk/tlog/schema"
+)
+
+// Limiter is interface that needs to be implemented
+// in order for the decoder to know which aggregations
+// it needs to decode
+type Limiter interface {
+	// EndAgg returns true if it is the end  of the
+	// aggregation we want to decode
+	EndAgg(*schema.TlogAggregation, schema.TlogBlock_List) bool
+
+	// StartAgg returns true if it is the start of the
+	// aggregation we want to decode
+	StartAgg(*schema.TlogAggregation, schema.TlogBlock_List) bool
+
+	StartBlock(schema.TlogBlock) bool
+	EndBlock(schema.TlogBlock) bool
+}
+
+// LimitByTimestamp implements limiter based on the timestamp
+type LimitByTimestamp struct {
+	startTs uint64
+	endTs   uint64
+}
+
+// NewLimitByTimestamp creates new LimitByTimestamp limiter
+func NewLimitByTimestamp(startTs, endTs uint64) LimitByTimestamp {
+	return LimitByTimestamp{
+		startTs: startTs,
+		endTs:   endTs,
+	}
+}
+
+// EndAgg implements Limiter.EndAgg
+func (lbt LimitByTimestamp) EndAgg(agg *schema.TlogAggregation, blocks schema.TlogBlock_List) bool {
+	if lbt.endTs == 0 {
+		return false
+	}
+
+	// max timestamp of this aggregation is bigger than
+	// endTs
+	return blocks.At(blocks.Len()-1).Timestamp() > lbt.endTs && blocks.At(0).Timestamp() <= lbt.endTs
+}
+
+// StartAgg implements Limiter.StartAgg
+func (lbt LimitByTimestamp) StartAgg(agg *schema.TlogAggregation, blocks schema.TlogBlock_List) bool {
+	if lbt.startTs == 0 {
+		return false
+	}
+	return blocks.At(blocks.Len()-1).Timestamp() >= lbt.startTs && blocks.At(0).Timestamp() < lbt.startTs
+}
+
+// EndBlock implementes Limiter.EndBlock
+func (lbt LimitByTimestamp) EndBlock(block schema.TlogBlock) bool {
+	if lbt.endTs == 0 {
+		return false
+	}
+	return block.Timestamp() > lbt.endTs
+}
+
+// StartBlock implements Limiter.StartBlock
+func (lbt LimitByTimestamp) StartBlock(block schema.TlogBlock) bool {
+	if lbt.startTs == 0 {
+		return true
+	}
+	return block.Timestamp() >= lbt.startTs
+}
+
+type LimitBySequence struct {
+	startSeq uint64
+	endSeq   uint64
+}
+
+func NewLimitBySequence(startSeq, endSeq uint64) LimitBySequence {
+	return LimitBySequence{
+		startSeq: startSeq,
+		endSeq:   endSeq,
+	}
+}
+
+// EndAgg implements Limiter.EndAgg
+func (lbt LimitBySequence) EndAgg(agg *schema.TlogAggregation, blocks schema.TlogBlock_List) bool {
+	if lbt.endSeq == 0 {
+		return false
+	}
+
+	return blocks.At(blocks.Len()-1).Sequence() > lbt.endSeq && blocks.At(0).Sequence() <= lbt.endSeq
+}
+
+// StartAgg implements Limiter.StartAgg
+func (lbt LimitBySequence) StartAgg(agg *schema.TlogAggregation, blocks schema.TlogBlock_List) bool {
+	if lbt.startSeq == 0 {
+		return false
+	}
+	return blocks.At(blocks.Len()-1).Sequence() >= lbt.startSeq && blocks.At(0).Sequence() < lbt.startSeq
+}
+
+// EndBlock implementes Limiter.EndBlock
+func (lbt LimitBySequence) EndBlock(block schema.TlogBlock) bool {
+	if lbt.endSeq == 0 {
+		return false
+	}
+	return block.Sequence() > lbt.endSeq
+}
+
+// StartBlock implements Limiter.StartBlock
+func (lbt LimitBySequence) StartBlock(block schema.TlogBlock) bool {
+	if lbt.startSeq == 0 {
+		return true
+	}
+	return block.Sequence() >= lbt.startSeq
+}

--- a/tlog/tlogclient/examples/walk_history/main.go
+++ b/tlog/tlogclient/examples/walk_history/main.go
@@ -54,7 +54,7 @@ func main() {
 		log.Fatalf("tlog decoder creation failed:%v", err)
 	}
 
-	aggChan := dec.Decode(0, 0)
+	aggChan := dec.Decode(decoder.NewLimitByTimestamp(0, 0))
 
 	for {
 		da, more := <-aggChan

--- a/tlog/tlogclient/reconnect_test.go
+++ b/tlog/tlogclient/reconnect_test.go
@@ -1,6 +1,7 @@
 package tlogclient
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -14,6 +15,9 @@ import (
 // TestReconnectFromSend test client can connect again after getting disconnected
 // when doing 'Send'
 func TestReconnectFromSend(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const (
 		vdisk         = "12345"
 		firstSequence = 0
@@ -22,7 +26,7 @@ func TestReconnectFromSend(t *testing.T) {
 
 	serv, _, err := createTestServer()
 	assert.Nil(t, err)
-	go serv.Listen()
+	go serv.Listen(ctx)
 
 	client, err := New(serv.ListenAddr(), vdisk, firstSequence, false)
 	assert.Nil(t, err)
@@ -54,13 +58,16 @@ func TestReconnectFromSend(t *testing.T) {
 // (4) Send ForceFlush using private API, so it doesn't have reconnect logic
 // (5) wait for the confirmation, that force flush arrived
 func TestReconnectFromRead(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const (
 		vdisk = "12345"
 	)
 	// test server
 	s, _, err := createTestServer()
 	assert.Nil(t, err)
-	go s.Listen()
+	go s.Listen(ctx)
 
 	//readTimeout = 10 * time.Millisecond
 	// Step #1
@@ -102,13 +109,16 @@ func (c *Client) forceFlushAtSeq(seq uint64) error {
 }
 
 func TestReconnectFromForceFlush(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const (
 		vdisk = "12345"
 	)
 	// test server
 	s, _, err := createTestServer()
 	assert.Nil(t, err)
-	go s.Listen()
+	go s.Listen(ctx)
 
 	// Create client
 	client, err := New(s.ListenAddr(), vdisk, 0, false)

--- a/tlog/tlogclient/resend_test.go
+++ b/tlog/tlogclient/resend_test.go
@@ -1,6 +1,7 @@
 package tlogclient
 
 import (
+	"context"
 	"io"
 	"sync"
 	"testing"
@@ -117,6 +118,9 @@ func (ds *dummyServer) run(t *testing.T, logsToIgnore map[uint64]struct{}) error
 // it simulates timeout by create dummy server that
 // ignore some of the logs
 func TestResendTimeout(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	const (
 		vdisk         = "12345"
 		firstSequence = 0
@@ -127,7 +131,7 @@ func TestResendTimeout(t *testing.T) {
 	// TODO : remove the need to this unused server
 	unusedServer, _, err := createTestServer()
 	assert.Nil(t, err)
-	go unusedServer.Listen()
+	go unusedServer.Listen(ctx)
 
 	// list of sequences for the server to ignores.
 	// it simulates timeout

--- a/tlog/tlogserver/aggmq/aggmq.go
+++ b/tlog/tlogserver/aggmq/aggmq.go
@@ -1,7 +1,6 @@
 package aggmq
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -26,9 +25,8 @@ type AggProcessorConfig struct {
 
 // AggProcessorReq defines request to the processor provider
 type AggProcessorReq struct {
-	Comm    *AggComm
-	Config  AggProcessorConfig
-	Context context.Context
+	Comm   *AggComm
+	Config AggProcessorConfig
 }
 
 // MQ defines this message queue
@@ -50,7 +48,7 @@ func NewMQ() *MQ {
 
 // AskProcessor as for aggregation processor.
 // we currently only have slave syncer
-func (mq *MQ) AskProcessor(ctx context.Context, apc AggProcessorConfig) (*AggComm, error) {
+func (mq *MQ) AskProcessor(apc AggProcessorConfig) (*AggComm, error) {
 	mq.mux.Lock()
 	defer mq.mux.Unlock()
 
@@ -62,9 +60,8 @@ func (mq *MQ) AskProcessor(ctx context.Context, apc AggProcessorConfig) (*AggCom
 	comm := newAggComm(mq, apc.VdiskID)
 	// ask for processor
 	mq.NeedProcessorCh <- AggProcessorReq{
-		Comm:    comm,
-		Config:  apc,
-		Context: ctx,
+		Comm:   comm,
+		Config: apc,
 	}
 
 	// wait for the resp

--- a/tlog/tlogserver/server/force_flush_test.go
+++ b/tlog/tlogserver/server/force_flush_test.go
@@ -19,12 +19,15 @@ import (
 // 4. create goroutine to wait for force flushed seq
 // 5. client send the logs
 func TestForceFlushAtSeq(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	// Step #1
 	// create and start server
 	s, conf, err := createTestServer(t, 1000)
 	assert.Nil(t, err)
 
-	go s.Listen()
+	go s.Listen(ctx)
 
 	t.Logf("listen addr=%v", s.ListenAddr())
 	const (
@@ -52,7 +55,6 @@ func TestForceFlushAtSeq(t *testing.T) {
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	respChan := client.Recv()
 
@@ -89,12 +91,15 @@ func TestForceFlushAtSeqPossibleRace(t *testing.T) {
 // 4. client send the logs
 // 5. client force flushed that sequence
 func testForceFlushAtSeqPossibleRace(t *testing.T, withSleep bool) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	// Step #1
 	// create and start server
 	s, conf, err := createTestServer(t, 1000)
 	assert.Nil(t, err)
 
-	go s.Listen()
+	go s.Listen(ctx)
 
 	t.Logf("listen addr=%v", s.ListenAddr())
 	const (
@@ -117,7 +122,6 @@ func testForceFlushAtSeqPossibleRace(t *testing.T, withSleep bool) {
 	}
 
 	var wg sync.WaitGroup
-	ctx, cancelFunc := context.WithCancel(context.Background())
 	wg.Add(1)
 
 	respChan := client.Recv()

--- a/tlog/tlogserver/server/reset_first_seq_test.go
+++ b/tlog/tlogserver/server/reset_first_seq_test.go
@@ -23,6 +23,9 @@ import (
 // (5) Client #2 send another (n*FlushSize) logs
 // (6) Client #2 must receive flush response for all of it's logs
 func TestResetFirstSequence(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	// config
 	conf := testConf
 	conf.FlushTime = 100 // make it high value to avoid flush by timeout
@@ -34,7 +37,7 @@ func TestResetFirstSequence(t *testing.T) {
 	s, err := NewServer(conf, poolFactory)
 	assert.Nil(t, err)
 
-	go s.Listen()
+	go s.Listen(ctx)
 
 	t.Logf("listen addr=%v", s.ListenAddr())
 	const (

--- a/tlog/tlogserver/server/server_test.go
+++ b/tlog/tlogserver/server/server_test.go
@@ -117,7 +117,7 @@ func TestEndToEnd(t *testing.T) {
 		expectedVdiskID, conf.PrivKey, conf.HexNonce)
 	assert.Nil(t, err)
 
-	aggChan := dec.Decode(0, 0)
+	aggChan := dec.Decode(decoder.NewLimitByTimestamp(0, 0))
 
 	aggReceived := 0
 	for {
@@ -271,7 +271,7 @@ func TestUnordered(t *testing.T) {
 		vdiskID, conf.PrivKey, conf.HexNonce)
 	assert.Nil(t, err)
 
-	aggChan := dec.Decode(0, 0)
+	aggChan := dec.Decode(decoder.NewLimitByTimestamp(0, 0))
 
 	var expectedSequence = uint64(firstSequence)
 	for {

--- a/tlog/tlogserver/server/server_test.go
+++ b/tlog/tlogserver/server/server_test.go
@@ -29,6 +29,9 @@ var (
 
 // Test that we can send the data to tlog and decode it again correctly
 func TestEndToEnd(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	// config
 	conf := testConf
 
@@ -39,7 +42,7 @@ func TestEndToEnd(t *testing.T) {
 	s, err := NewServer(conf, poolFactory)
 	assert.Nil(t, err)
 
-	go s.Listen()
+	go s.Listen(ctx)
 	t.Logf("listen addr=%v", s.ListenAddr())
 
 	const (
@@ -154,6 +157,9 @@ func TestEndToEnd(t *testing.T) {
 
 // Test tlog server ability to handle unordered message
 func TestUnordered(t *testing.T) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	// config
 	conf := testConf
 
@@ -164,7 +170,7 @@ func TestUnordered(t *testing.T) {
 	s, err := NewServer(conf, poolFactory)
 	assert.Nil(t, err)
 
-	go s.Listen()
+	go s.Listen(ctx)
 
 	t.Logf("listen addr=%v", s.ListenAddr())
 	const (
@@ -191,8 +197,6 @@ func TestUnordered(t *testing.T) {
 	for i := 0; i < numLogs; i++ {
 		seqs = append(seqs, uint64(i)+firstSequence)
 	}
-
-	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	// send tlog
 	go func() {

--- a/tlog/tlogserver/server/vdisk.go
+++ b/tlog/tlogserver/server/vdisk.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"net"
 	"sync"
 	"time"
@@ -97,9 +96,7 @@ func newVdisk(aggMq *aggmq.MQ, vdiskID string, f *flusher, firstSequence uint64,
 			PrivKey:  flusherConf.PrivKey,
 			HexNonce: flusherConf.HexNonce,
 		}
-		ctx, _ := context.WithCancel(context.Background()) // TODO : save and use the context properly
-
-		aggComm, err = aggMq.AskProcessor(ctx, apc)
+		aggComm, err = aggMq.AskProcessor(apc)
 		if err != nil {
 			return nil, err
 		}

--- a/tlog/tlogserver/slavesync_test.go
+++ b/tlog/tlogserver/slavesync_test.go
@@ -175,7 +175,7 @@ func testSlaveSyncReal(t *testing.T, isRead bool) {
 // - it proves that even slave syncer started late, the slave still synced
 // TODO : we disabled it because of high memory usage (6GB)
 //        the solution is to create more memory efficient redis pool
-func testSlaveSyncRestart(t *testing.T) {
+func TestSlaveSyncRestart(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	defer cancelFunc()
 
@@ -346,7 +346,7 @@ func newTlogRedisPoolAndConfig(vdiskID string, blockSize, size uint64) (*redisst
 				ReadOnly:           false,
 				Size:               size,
 				StorageCluster:     "mycluster",
-				Type:               config.VdiskTypeBoot,
+				Type:               config.VdiskTypeDB,
 				TlogSlaveSync:      true,
 				TlogStorageCluster: "tlogCluster",
 			},
@@ -395,7 +395,7 @@ func newRedisPoolAndConfig(vdiskID string, blockSize, size uint64,
 				ReadOnly:           false,
 				Size:               size,
 				StorageCluster:     "mycluster",
-				Type:               config.VdiskTypeBoot,
+				Type:               config.VdiskTypeDB,
 				TlogSlaveSync:      true,
 				TlogStorageCluster: "tlogCluster",
 			},

--- a/zeroctl/cmd/restore/vdisk.go
+++ b/zeroctl/cmd/restore/vdisk.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zero-os/0-Disk/gonbdserver/nbd"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbdserver/ardb"
+	"github.com/zero-os/0-Disk/tlog/tlogclient/decoder"
 	"github.com/zero-os/0-Disk/tlog/tlogclient/player"
 	"github.com/zero-os/0-Disk/zeroctl/cmd/config"
 )
@@ -65,7 +66,7 @@ func restoreVdisk(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return player.Replay(vdiskCfg.StartTs, vdiskCfg.EndTs)
+	return player.Replay(decoder.NewLimitByTimestamp(vdiskCfg.StartTs, vdiskCfg.EndTs))
 }
 
 // create a new backend, used for writing

--- a/zeroctl/cmd/restore/vdisk.go
+++ b/zeroctl/cmd/restore/vdisk.go
@@ -66,7 +66,8 @@ func restoreVdisk(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return player.Replay(decoder.NewLimitByTimestamp(vdiskCfg.StartTs, vdiskCfg.EndTs))
+	_, err = player.Replay(decoder.NewLimitByTimestamp(vdiskCfg.StartTs, vdiskCfg.EndTs))
+	return err
 }
 
 // create a new backend, used for writing

--- a/zeroctl/cmd/restore/vdisk_test.go
+++ b/zeroctl/cmd/restore/vdisk_test.go
@@ -178,7 +178,7 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 		return
 	}
 
-	err = player.Replay(decoder.NewLimitByTimestamp(startTs, lastBlockTs))
+	_, err = player.Replay(decoder.NewLimitByTimestamp(startTs, lastBlockTs))
 
 	t.Log("8. Validate that all replayed data is again retrievable and correct;")
 
@@ -207,7 +207,7 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 	}
 
 	t.Log("10 replay last block")
-	err = player.Replay(decoder.NewLimitByTimestamp(lastBlockTs, 0))
+	_, err = player.Replay(decoder.NewLimitByTimestamp(lastBlockTs, 0))
 
 	t.Log("11. Validate that last block is again retrievable and correct;")
 	{

--- a/zeroctl/cmd/restore/vdisk_test.go
+++ b/zeroctl/cmd/restore/vdisk_test.go
@@ -30,6 +30,9 @@ func TestEndToEndReplayDBdisk(t *testing.T) {
 }
 
 func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+	defer cancelFunc()
+
 	t.Log("1. Start a tlogserver;")
 
 	testConf := &server.Config{
@@ -52,7 +55,7 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 	}
 
 	t.Log("make tlog server listen")
-	go s.Listen()
+	go s.Listen(ctx)
 
 	var (
 		tlogrpc = s.ListenAddr()
@@ -68,8 +71,6 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 	)
 
 	t.Log("2. Start an NBDServer Backend with tlogclient integration;")
-
-	ctx := context.Background()
 
 	t.Log("creating new test backend")
 	backend, err := newTestBackend(ctx, t, vdiskID, vdiskType, tlogrpc, blockSize, size)

--- a/zeroctl/cmd/restore/vdisk_test.go
+++ b/zeroctl/cmd/restore/vdisk_test.go
@@ -12,6 +12,7 @@ import (
 	zerodiskcfg "github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/gonbdserver/nbd"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/tlog/tlogclient/decoder"
 	"github.com/zero-os/0-Disk/tlog/tlogclient/player"
 	"github.com/zero-os/0-Disk/tlog/tlogserver/server"
 
@@ -177,7 +178,7 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 		return
 	}
 
-	err = player.Replay(startTs, lastBlockTs)
+	err = player.Replay(decoder.NewLimitByTimestamp(startTs, lastBlockTs))
 
 	t.Log("8. Validate that all replayed data is again retrievable and correct;")
 
@@ -206,7 +207,7 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 	}
 
 	t.Log("10 replay last block")
-	err = player.Replay(lastBlockTs, 0)
+	err = player.Replay(decoder.NewLimitByTimestamp(lastBlockTs, 0))
 
 	t.Log("11. Validate that last block is again retrievable and correct;")
 	{


### PR DESCRIPTION
Part of #38:
- restart slave syncer in case of error
- on (re)start slave syncer checks for slave's latest sequence, make sure it fully synced with what tlogserver have