### PR TITLE
Force flush resend

### DIFF
--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -306,12 +306,11 @@ func (c *Client) createConn() error {
 }
 
 // ForceFlushAtSeq force flush at given sequence
+// NOTE : this func doesn't have retry logic, user need to
+// add it
 func (c *Client) ForceFlushAtSeq(seq uint64) error {
 	c.wLock.Lock()
 	defer c.wLock.Unlock()
-
-	// TODO :
-	// - add resend
 
 	sender := func() (interface{}, error) {
 		if err := tlog.WriteMessageType(c.bw, tlog.MessageForceFlushAtSeq); err != nil {


### PR DESCRIPTION
Fixes #256 
- reconnect already added in previous PR
- resend not added because it brings too much complexity for little gain. The user need to do the retry by himself, which is simple to do. Already added resend logic to the nbdserver