### PR TITLE
Tlogclient multiple server

### DIFF
--- a/nbdserver/ardb/tlog.go
+++ b/nbdserver/ardb/tlog.go
@@ -25,7 +25,7 @@ const (
 )
 
 func newTlogStorage(vdiskID, tlogrpc, configPath string, blockSize int64, storage backendStorage) (backendStorage, error) {
-	client, err := tlogclient.New(tlogrpc, vdiskID, 0, true)
+	client, err := tlogclient.New([]string{tlogrpc}, vdiskID, 0, true)
 	if err != nil {
 		return nil, fmt.Errorf("tlogStorage requires a valid tlogclient: %s", err.Error())
 	}

--- a/tlog/tlogclient/blockbuffer/buffer.go
+++ b/tlog/tlogclient/blockbuffer/buffer.go
@@ -3,7 +3,6 @@ package blockbuffer
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -16,51 +15,63 @@ var (
 )
 
 // Buffer defines buffer of tlog blocks that already sent
-// but still waiting to be succesfully received by the server
+// but still waiting for:
+// - to be succesfully received by the server
+// - to be flushed
 type Buffer struct {
-	lock            sync.RWMutex
-	entries         map[uint64]*entry
-	seqToTimeout    []uint64
-	readyChan       chan *schema.TlogBlock
-	timeout         time.Duration
-	maxRetry        int
-	highestSequence uint64 // the highest sequence we received
+	lock sync.RWMutex
+
+	// map of sent block
+	entries map[uint64]*entry
+
+	// Array of ordered sent sequence.
+	// It is used to find the timed out block
+	seqToTimeout []uint64
+
+	// map of entries that waiting to be flushed
+	waitToFlush map[uint64]*entry
+
+	// channel of blocks that ready to be re-sent
+	readyChan chan *schema.TlogBlock
+
+	// block timeout value. Block will be re-send
+	// if reach this timeout value
+	timeout time.Duration
+
+	// the highest sequence we received
+	highestSequence uint64
 }
 
 // NewBuffer creates a new tlog blocks buffer
 func NewBuffer(timeout time.Duration) *Buffer {
 	return &Buffer{
-		readyChan: make(chan *schema.TlogBlock, 1),
-		entries:   map[uint64]*entry{},
-		timeout:   timeout,
-		maxRetry:  3,
+		readyChan:   make(chan *schema.TlogBlock, 1),
+		entries:     make(map[uint64]*entry),
+		waitToFlush: make(map[uint64]*entry),
+		timeout:     timeout,
 	}
 }
 
-// Len returns number of blocks in this buffer
-func (b *Buffer) Len() int {
+// SetResendAll resets this buffer, make all blocks
+// need to be resend right now
+func (b *Buffer) SetResendAll() {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
-	return len(b.entries)
-}
 
-// Promote sets a block with given sequence to be timed out now.
-// It returns error if the block already exceed it's retry quota.
-func (b *Buffer) Promote(seq uint64) error {
-	b.lock.Lock()
-	defer b.lock.Unlock()
+	b.seqToTimeout = make([]uint64, 0, len(b.entries)+len(b.waitToFlush))
 
-	ent, exist := b.entries[seq]
-	if !exist {
-		return fmt.Errorf("tlog client blockbuffer: seq %v not exist", seq)
+	for seq, ent := range b.entries {
+		b.seqToTimeout = append(b.seqToTimeout, seq)
+		ent.setZero()
 	}
 
-	if ent.retryNum >= b.maxRetry {
-		return ErrRetryExceeded
+	for seq, ent := range b.waitToFlush {
+		b.seqToTimeout = append(b.seqToTimeout, seq)
+		ent.setZero()
+		b.entries[seq] = ent
 	}
 
-	ent.setTimeout()
-	return nil
+	b.waitToFlush = make(map[uint64]*entry)
 }
 
 // Add adds a block to this buffer.
@@ -91,10 +102,30 @@ func (b *Buffer) Add(block *schema.TlogBlock) {
 	b.entries[seq] = ent
 }
 
-// Delete deletes an entry from buffer.
-func (b *Buffer) Delete(seq uint64) {
+func (b *Buffer) LenWaitFlush() {
+}
+
+// SetFlushed set this sequence as succesfully flushed
+func (b *Buffer) SetFlushed(seqs []uint64) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
+
+	for _, seq := range seqs {
+		delete(b.waitToFlush, seq)
+		delete(b.entries, seq) // we normally don't need to do this
+	}
+}
+
+// SetSent set this sequence as succesfully sent
+func (b *Buffer) SetSent(seq uint64) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	ent, ok := b.entries[seq]
+	if !ok {
+		return
+	}
+	b.waitToFlush[seq] = ent
 
 	delete(b.entries, seq)
 }

--- a/tlog/tlogclient/blockbuffer/entry.go
+++ b/tlog/tlogclient/blockbuffer/entry.go
@@ -35,3 +35,8 @@ func (ent *entry) isTimeout(now time.Time) bool {
 func (ent *entry) setTimeout() {
 	ent.timeout = time.Now().UnixNano()
 }
+
+func (ent *entry) setZero() {
+	ent.retryNum = 0
+	ent.timeout = 0
+}

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -244,8 +244,10 @@ func (c *Client) Recv() <-chan *Result {
 					switch tr.Status {
 					case tlog.BlockStatusRecvOK:
 						if len(tr.Sequences) > 0 { // should always be true, but we anticipate.
-							c.blockBuffer.Delete(tr.Sequences[0])
+							c.blockBuffer.SetSent(tr.Sequences[0])
 						}
+					case tlog.BlockStatusFlushOK:
+						c.blockBuffer.SetFlushed(tr.Sequences)
 					case tlog.BlockStatusWaitNbdSlaveSyncReceived:
 						c.signalCond(c.waitSlaveSyncCond)
 					}

--- a/tlog/tlogclient/common_test.go
+++ b/tlog/tlogclient/common_test.go
@@ -1,0 +1,49 @@
+package tlogclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zero-os/0-Disk/tlog"
+	"github.com/zero-os/0-Disk/tlog/schema"
+)
+
+func testClientSend(t *testing.T, client *Client, startSeq, endSeq uint64, data []byte) {
+	for x := startSeq; x <= endSeq; x++ {
+		err := client.Send(schema.OpWrite, x, x, x, data, uint64(len(data)))
+		assert.Nil(t, err)
+	}
+
+}
+func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan *Result,
+	cancelFunc func(), seqWait uint64) {
+
+	for {
+		select {
+		case re := <-respChan:
+			if !assert.Nil(t, re.Err) {
+				cancelFunc()
+				return
+			}
+			status := re.Resp.Status
+			if !assert.Equal(t, true, status > 0) {
+				cancelFunc()
+				return
+			}
+
+			if status == tlog.BlockStatusFlushOK {
+				seqs := re.Resp.Sequences
+				seq := seqs[len(seqs)-1]
+
+				if seq >= seqWait { // we've received all sequences
+					return
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+
+}

--- a/tlog/tlogclient/examples/send_tlog/client.go
+++ b/tlog/tlogclient/examples/send_tlog/client.go
@@ -29,7 +29,7 @@ func main() {
 		dataLen       = 4096
 	)
 
-	client, err := client.New("127.0.0.1:11211", vdiskID, firstSequence, false)
+	client, err := client.New([]string{"127.0.0.1:11211"}, vdiskID, firstSequence, false)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/tlog/tlogclient/multiple_server_test.go
+++ b/tlog/tlogclient/multiple_server_test.go
@@ -1,0 +1,228 @@
+package tlogclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/redisstub"
+	"github.com/zero-os/0-Disk/tlog"
+	"github.com/zero-os/0-Disk/tlog/tlogclient/decoder"
+	"github.com/zero-os/0-Disk/tlog/tlogserver/server"
+)
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}
+
+type testTwoServerConf struct {
+	firstSendStartSeq uint64
+	firstSendEndSeq   uint64
+	firstWaitEndSeq   uint64
+
+	secondSendStartSeq uint64
+	secondSendEndSeq   uint64
+	secondWaitEndSeq   uint64
+}
+
+// Test client with two tlog servers in normal condition:
+// - tlog 1 flush all it receive
+// - tlog1 lost/destroyed
+// - tlog 2 continue the work
+// Start 2 tlogservers with same storage, flushSize = 25
+// start client,
+// - connect to server
+// - send log 1 - 100
+// - wait until all flushed
+// stop tlog server 1 // or remove it from client addrs and then disconnect
+// - send log 101-200
+// - wait until all flushed
+// Start tlog decoder
+// - make sure all sequence successfully decoded
+func TestMultipleServerBasic(t *testing.T) {
+	conf := testTwoServerConf{
+		firstSendStartSeq:  0,
+		firstSendEndSeq:    99,
+		firstWaitEndSeq:    99,
+		secondSendStartSeq: 100,
+		secondSendEndSeq:   199,
+		secondWaitEndSeq:   199,
+	}
+	testTwoServers(t, conf)
+}
+
+// TestMultipleServerResendUnflushed test multiple servers
+// in case the 1st tlog server has some unflushed blocks
+func TestMultipleServerResendUnflushed(t *testing.T) {
+	conf := testTwoServerConf{
+		firstSendStartSeq:  0,
+		firstSendEndSeq:    90,
+		firstWaitEndSeq:    74,
+		secondSendStartSeq: 91,
+		secondSendEndSeq:   199,
+		secondWaitEndSeq:   199,
+	}
+	testTwoServers(t, conf)
+
+}
+
+func testTwoServers(t *testing.T, ttConf testTwoServerConf) {
+	const (
+		vdiskID  = "myimg"
+		firstSeq = 0
+		numLogs1 = 100
+	)
+	data := make([]byte, 4096)
+
+	ctx1, cancelFunc1 := context.WithCancel(context.Background())
+	defer cancelFunc1()
+
+	ctx2, cancelFunc2 := context.WithCancel(context.Background())
+	defer cancelFunc2()
+
+	stors, err := newRedisStors(vdiskID)
+	assert.Nil(t, err)
+	defer func() {
+		for _, stor := range stors {
+			stor.Close()
+		}
+	}()
+
+	t.Log("Create tlog servers")
+	pool1, _, t1, err := createTestTlogServer(ctx1, vdiskID, stors)
+	assert.Nil(t, err)
+	defer pool1.Close()
+
+	pool2, tlogConf, t2, err := createTestTlogServer(ctx2, vdiskID, stors)
+	assert.Nil(t, err)
+	defer pool2.Close()
+
+	t.Log("connect client")
+	client, err := New([]string{t1.ListenAddr(), t2.ListenAddr()}, vdiskID, 0, false)
+	assert.Nil(t, err)
+
+	respChan := client.Recv()
+
+	t.Log("write data to server #1")
+
+	seqs := make(map[uint64]struct{})
+	for i := ttConf.firstSendStartSeq; i <= ttConf.firstSendEndSeq; i++ {
+		seqs[i] = struct{}{}
+	}
+
+	go func() {
+		testClientSend(t, client, ttConf.firstSendStartSeq, ttConf.firstSendEndSeq, data)
+	}()
+
+	// wait for it to be flushed
+	testClientWaitSeqFlushed(ctx1, t, respChan, cancelFunc1, ttConf.firstWaitEndSeq)
+
+	// simulate stopping server 1
+	// - cancel it (not works)
+	// - remove server 1 from client's addrs and disconnect the socket
+	cancelFunc1()
+	client.addrs = client.addrs[1:]
+	client.conn.Close()
+
+	t.Log("write data to server #2")
+	for i := ttConf.secondSendStartSeq; i <= ttConf.secondSendEndSeq; i++ {
+		seqs[i] = struct{}{}
+	}
+
+	go func() {
+		testClientSend(t, client, ttConf.secondSendStartSeq, ttConf.secondSendEndSeq, data)
+	}()
+
+	// wait for it to be flushed
+	testClientWaitSeqFlushed(ctx2, t, respChan, cancelFunc1, ttConf.secondWaitEndSeq)
+
+	// validate with the decoder
+	flushedAll, err := validateWithDecoder(seqs, pool2, tlogConf.K, tlogConf.M, vdiskID,
+		tlogConf.PrivKey, tlogConf.HexNonce, ttConf.firstSendStartSeq, ttConf.secondSendEndSeq)
+	assert.Nil(t, err)
+	assert.True(t, flushedAll)
+}
+
+func validateWithDecoder(seqs map[uint64]struct{}, pool tlog.RedisPool, k, m int,
+	vdiskID, privKey, hexNonce string, startSeq, endSeq uint64) (bool, error) {
+
+	dec, err := decoder.New(pool, k, m, vdiskID, privKey, hexNonce)
+	if err != nil {
+		return false, err
+	}
+
+	aggChan := dec.Decode(decoder.NewLimitBySequence(startSeq, endSeq))
+	for da := range aggChan {
+		if da.Err != nil {
+			break
+		}
+		agg := da.Agg
+		blocks, err := agg.Blocks()
+		if err != nil {
+			return false, err
+		}
+		for i := 0; i < blocks.Len(); i++ {
+			block := blocks.At(i)
+			delete(seqs, block.Sequence())
+		}
+	}
+	return len(seqs) == 0, nil
+}
+
+func createTestTlogServer(ctx context.Context, vdiskID string,
+	stors []*redisstub.MemoryRedis) (tlog.RedisPool, *server.Config, *server.Server, error) {
+	conf := server.DefaultConfig()
+	conf.ListenAddr = ""
+	conf.K = 1
+	conf.M = 1
+	conf.FlushSize = 25
+
+	addrs := []string{}
+	for _, stor := range stors {
+		addrs = append(addrs, stor.Address())
+	}
+	serverConfigs, err := config.ParseCSStorageServerConfigStrings(strings.Join(addrs, ","))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// create any kind of valid pool factory
+	poolFact, err := tlog.AnyRedisPoolFactory(tlog.RedisPoolFactoryConfig{
+		RequiredDataServerCount: len(stors),
+		ServerConfigs:           serverConfigs,
+		AutoFill:                true,
+		AllowInMemory:           true,
+	})
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	pool, err := poolFact.NewRedisPool(vdiskID)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	server, err := server.NewServer(conf, poolFact)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	go server.Listen(ctx)
+	return pool, conf, server, nil
+}
+
+func newRedisStors(vdiskID string) (stors []*redisstub.MemoryRedis, err error) {
+	stor1 := redisstub.NewMemoryRedis()
+	stor2 := redisstub.NewMemoryRedis()
+
+	stors = append(stors, stor1, stor2)
+
+	go stor1.Listen()
+	go stor2.Listen()
+
+	return
+}

--- a/tlog/tlogclient/reconnect_test.go
+++ b/tlog/tlogclient/reconnect_test.go
@@ -28,7 +28,7 @@ func TestReconnectFromSend(t *testing.T) {
 	assert.Nil(t, err)
 	go serv.Listen(ctx)
 
-	client, err := New(serv.ListenAddr(), vdisk, firstSequence, false)
+	client, err := New([]string{serv.ListenAddr()}, vdisk, firstSequence, false)
 	assert.Nil(t, err)
 	defer client.Close()
 
@@ -71,7 +71,7 @@ func TestReconnectFromRead(t *testing.T) {
 
 	//readTimeout = 10 * time.Millisecond
 	// Step #1
-	client, err := New(s.ListenAddr(), vdisk, 0, false)
+	client, err := New([]string{s.ListenAddr()}, vdisk, 0, false)
 	assert.Nil(t, err)
 
 	// Step #2
@@ -121,7 +121,7 @@ func TestReconnectFromForceFlush(t *testing.T) {
 	go s.Listen(ctx)
 
 	// Create client
-	client, err := New(s.ListenAddr(), vdisk, 0, false)
+	client, err := New([]string{s.ListenAddr()}, vdisk, 0, false)
 	assert.Nil(t, err)
 
 	// Simulate closed connection

--- a/tlog/tlogclient/resend_test.go
+++ b/tlog/tlogclient/resend_test.go
@@ -145,7 +145,7 @@ func TestResendTimeout(t *testing.T) {
 	ds := newDummyServer(unusedServer)
 	go ds.run(t, logsToIgnore)
 
-	client, err := New(unusedServer.ListenAddr(), vdisk, firstSequence, false)
+	client, err := New([]string{unusedServer.ListenAddr()}, vdisk, firstSequence, false)
 	assert.Nil(t, err)
 	defer client.Close()
 

--- a/tlog/tlogserver/server/force_flush_test.go
+++ b/tlog/tlogserver/server/force_flush_test.go
@@ -44,7 +44,7 @@ func TestForceFlushAtSeq(t *testing.T) {
 	forceFlushedSeq := uint64(numLogs - 5)
 
 	// create tlog client
-	client, err := tlogclient.New(s.ListenAddr(), vdiskID, firstSequence, false)
+	client, err := tlogclient.New([]string{s.ListenAddr()}, vdiskID, firstSequence, false)
 	if !assert.Nil(t, err) {
 		return
 	}
@@ -116,7 +116,7 @@ func testForceFlushAtSeqPossibleRace(t *testing.T, withSleep bool) {
 	forceFlushedSeq := uint64(numLogs - 1)
 
 	// create tlog client
-	client, err := tlogclient.New(s.ListenAddr(), vdiskID, firstSequence, false)
+	client, err := tlogclient.New([]string{s.ListenAddr()}, vdiskID, firstSequence, false)
 	if !assert.Nil(t, err) {
 		return
 	}

--- a/tlog/tlogserver/server/reset_first_seq_test.go
+++ b/tlog/tlogserver/server/reset_first_seq_test.go
@@ -48,7 +48,7 @@ func TestResetFirstSequence(t *testing.T) {
 
 	// Step #1
 	// create tlog client
-	client1, err := tlogclient.New(s.ListenAddr(), vdiskID, 0, false)
+	client1, err := tlogclient.New([]string{s.ListenAddr()}, vdiskID, 0, false)
 	if !assert.Nil(t, err) {
 		return
 	}
@@ -62,7 +62,7 @@ func TestResetFirstSequence(t *testing.T) {
 	client1.Close()
 
 	// Step #3
-	client2, err := tlogclient.New(s.ListenAddr(), vdiskID, 0, true)
+	client2, err := tlogclient.New([]string{s.ListenAddr()}, vdiskID, 0, true)
 	if !assert.Nil(t, err) {
 		return
 	}

--- a/tlog/tlogserver/server/server_test.go
+++ b/tlog/tlogserver/server/server_test.go
@@ -51,7 +51,7 @@ func TestEndToEnd(t *testing.T) {
 	)
 
 	// create tlog client
-	client, err := tlogclient.New(s.ListenAddr(), expectedVdiskID, firstSequence, false)
+	client, err := tlogclient.New([]string{s.ListenAddr()}, expectedVdiskID, firstSequence, false)
 	if !assert.Nil(t, err) {
 		return
 	}
@@ -179,7 +179,7 @@ func TestUnordered(t *testing.T) {
 	)
 
 	// create tlog client
-	client, err := tlogclient.New(s.ListenAddr(), vdiskID, firstSequence, false)
+	client, err := tlogclient.New([]string{s.ListenAddr()}, vdiskID, firstSequence, false)
 	if !assert.Nil(t, err) {
 		return
 	}


### PR DESCRIPTION
Handle these cases (with unit tests):
- master crashed,  all received blocks already flushed to storage
- master crashed,  there are unflushed blocks
- master not crash, but failed to flush