### PR TITLE
Multiple-tlog support improvements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -60,6 +60,7 @@ const (
 type Config struct {
 	StorageClusters map[string]StorageClusterConfig `yaml:"storageClusters" valid:"required"`
 	Vdisks          map[string]VdiskConfig          `yaml:"vdisks" valid:"required"`
+	TlogRPC         string                          `yaml:"tlogrpc" valid:"optional"`
 
 	// information used to specialize validation of the config
 	user User

--- a/nbdserver/main.go
+++ b/nbdserver/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.StringVar(&profileAddress, "profile-address", "", "Enables profiling of this server as an http service")
 	flag.StringVar(&protocol, "protocol", "unix", "Protocol to listen on, 'tcp' or 'unix'")
 	flag.StringVar(&address, "address", "/tmp/nbd-socket", "Address to listen on, unix socket or tcp address, ':6666' for example")
-	flag.StringVar(&tlogrpcaddress, "tlogrpc", "", "Address of the tlog RPC, set to 'auto' to use the inmemory version (test/dev only)")
+	flag.StringVar(&tlogrpcaddress, "tlogrpc", "", "Addresses of the tlog RPC, set to 'auto' to use the inmemory version (test/dev only)")
 	flag.StringVar(&configPath, "config", "config.yml", "ARDB Config YAML File")
 	flag.Int64Var(&lbacachelimit, "lbacachelimit", ardb.DefaultLBACacheLimit,
 		fmt.Sprintf("Cache limit of LBA in bytes, needs to be higher then %d (bytes in 1 shard)", lba.BytesPerShard))

--- a/nbdserver/readme.md
+++ b/nbdserver/readme.md
@@ -50,6 +50,10 @@ vdisks: # A required map of vdisks,
                # which also defines if its deduped or nondeduped,
                # valid types are: `boot`, `db`, `cache` and `tmp`
   # ... more (optional) vdisks
+
+tlogrpc: 127.0.0.1:11211,127.0.0.1:11221 # addresses of the tlogrpc server.
+                                         # it is optional and going to be ignored if `tlogrpc` command 
+                                         # line option is specified
 ```
 
 As you can see, both the storage clusters and vdisks are configured in

--- a/tlog/tlogclient/blockbuffer/buffer.go
+++ b/tlog/tlogclient/blockbuffer/buffer.go
@@ -195,7 +195,10 @@ func (b *Buffer) TimedOut(ctx context.Context) <-chan *schema.TlogBlock {
 				}
 
 				// nanosecond left before timeout
+				b.lock.RLock()
 				toTime := ent.timeout - time.Now().UnixNano()
+				b.lock.RUnlock()
+
 				if toTime > 0 {
 					time.Sleep(time.Duration(toTime) * time.Nanosecond)
 				}

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -114,6 +114,7 @@ func (c *Client) ChangeServerAddrs(addrs []string) {
 	if len(addrs) == 0 {
 		return
 	}
+	log.Infof("tlogclient vdisk '%v' change server addrs to '%v'", c.vdiskID, addrs)
 
 	// reconnect client if current server not exist in the
 	// new addresses
@@ -128,6 +129,7 @@ func (c *Client) ChangeServerAddrs(addrs []string) {
 	c.addrs = addrs
 
 	if !curExist {
+		log.Infof("tlogclient vdisk '%v' current server is not in new address, close it", c.vdiskID)
 		c.conn.Close()
 	}
 

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -105,9 +105,12 @@ func New(addrs []string, vdiskID string, firstSequence uint64, resetFirstSeq boo
 	return client, nil
 }
 
+// ChangeServerAddrs change server addresses to the
+// given addresses addrs
 func (c *Client) ChangeServerAddrs(addrs []string) {
 	c.serverAddrLock.Lock()
 	c.serverAddrLock.Unlock()
+
 	if len(addrs) == 0 {
 		return
 	}
@@ -177,7 +180,6 @@ func (c *Client) reconnect(closedTime time.Time, switchOther bool) error {
 		// try other server
 		c.shiftServerAddr()
 	}
-	return err
 }
 
 // connect to server
@@ -435,7 +437,6 @@ func (c *Client) WaitNbdSlaveSync() error {
 			return nil
 		}
 	}
-	return ErrWaitSlaveSyncTimeout
 }
 
 // wait for a condition to happens

--- a/tlog/tlogclient/common_test.go
+++ b/tlog/tlogclient/common_test.go
@@ -48,5 +48,4 @@ func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan
 			return
 		}
 	}
-	return
 }

--- a/tlog/tlogclient/common_test.go
+++ b/tlog/tlogclient/common_test.go
@@ -23,7 +23,7 @@ func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan
 
 	for {
 		select {
-		case <-time.After(15 * time.Second):
+		case <-time.After(20 * time.Second):
 			t.Fatal("testClientWaitSeqFlushed timeout")
 		case re := <-respChan:
 			if re.Err != nil {

--- a/tlog/tlogserver/server/common_test.go
+++ b/tlog/tlogserver/server/common_test.go
@@ -1,9 +1,13 @@
 package server
 
 import (
+	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/zero-os/0-Disk/tlog"
+	"github.com/zero-os/0-Disk/tlog/tlogclient"
 )
 
 func createTestServer(t *testing.T, flushTime int) (*Server, *Config, error) {
@@ -18,4 +22,38 @@ func createTestServer(t *testing.T, flushTime int) (*Server, *Config, error) {
 
 	s, err := NewServer(conf, poolFactory)
 	return s, conf, err
+}
+
+// wait for sequence seqWait to be flushed
+func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan *tlogclient.Result,
+	cancelFunc func(), seqWait uint64, exactSeq bool) {
+
+	for {
+		select {
+		case re := <-respChan:
+			if !assert.Nil(t, re.Err) {
+				cancelFunc()
+				return
+			}
+			status := re.Resp.Status
+			if !assert.Equal(t, true, status > 0) {
+				continue
+			}
+
+			if status == tlog.BlockStatusFlushOK {
+				seqs := re.Resp.Sequences
+				seq := seqs[len(seqs)-1]
+
+				if exactSeq && seq == seqWait {
+					return
+				}
+				if !exactSeq && seq >= seqWait { // we've received all sequences
+					return
+				}
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+
 }

--- a/tlog/tlogserver/server/flusher.go
+++ b/tlog/tlogserver/server/flusher.go
@@ -144,6 +144,7 @@ func (f *flusher) encodeCapnp(blocks []*schema.TlogBlock, vd *vdisk) ([]byte, er
 
 func (f *flusher) storeEncoded(vd *vdisk, key []byte, encoded [][]byte) error {
 	var wg sync.WaitGroup
+	var errMux sync.Mutex
 
 	length := f.k + f.m
 	wg.Add(length)
@@ -159,6 +160,8 @@ func (f *flusher) storeEncoded(vd *vdisk, key []byte, encoded [][]byte) error {
 			ef := f.storeAndRetry(idx, key, vd.lastHashKey, blocks)
 			if !ef.Nil() {
 				err := fmt.Errorf("error during flush idx %v: %v", idx, ef)
+				errMux.Lock()
+				defer errMux.Unlock()
 				allErr = append(allErr, err)
 			}
 		}(i)

--- a/tlog/tlogserver/server/reset_first_seq_test.go
+++ b/tlog/tlogserver/server/reset_first_seq_test.go
@@ -109,41 +109,6 @@ func testClientSendWaitFlushResp(t *testing.T, c *tlogclient.Client, respChan <-
 	wg.Wait()
 }
 
-// wait for sequence seqWait to be flushed
-func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan *tlogclient.Result,
-	cancelFunc func(), seqWait uint64, exactSeq bool) {
-
-	for {
-		select {
-		case re := <-respChan:
-			if !assert.Nil(t, re.Err) {
-				cancelFunc()
-				return
-			}
-			status := re.Resp.Status
-			if !assert.Equal(t, true, status > 0) {
-				cancelFunc()
-				return
-			}
-
-			if status == tlog.BlockStatusFlushOK {
-				seqs := re.Resp.Sequences
-				seq := seqs[len(seqs)-1]
-
-				if exactSeq && seq == seqWait {
-					return
-				}
-				if !exactSeq && seq >= seqWait { // we've received all sequences
-					return
-				}
-			}
-		case <-ctx.Done():
-			return
-		}
-	}
-
-}
-
 // send `numLogs` of logs, starting from sequence number=seq
 func testClientSendLog(ctx context.Context, t *testing.T, c *tlogclient.Client, cancelFunc func(),
 	startSeq uint64, numLogs int, data []byte) {

--- a/tlog/tlogserver/server/server_test.go
+++ b/tlog/tlogserver/server/server_test.go
@@ -283,7 +283,10 @@ func TestUnordered(t *testing.T) {
 		if !more {
 			break
 		}
-		assert.Nil(t, da.Err)
+		if !assert.Nil(t, da.Err) {
+			t.Fatalf("unexpected error on the aggregations:%v", err)
+			return
+		}
 
 		agg := da.Agg
 

--- a/tlog/tlogserver/server/vdisk.go
+++ b/tlog/tlogserver/server/vdisk.go
@@ -349,14 +349,12 @@ func (vd *vdisk) runFlusher(ctx context.Context) {
 			// - already received
 			// - already flushed
 			seq := tlb.Sequence()
-			status := tlog.BlockStatusRecvOK
 			if seq <= lastSeqFlushed {
-				status = tlog.BlockStatusFlushOK
-			}
-			vd.respChan <- &BlockResponse{
-				Status:    status.Int8(),
-				Sequences: []uint64{seq},
-			}
+				vd.respChan <- &BlockResponse{
+					Status:    int8(tlog.BlockStatusFlushOK),
+					Sequences: []uint64{seq},
+				}
+			} // block received response already sent by main server handler
 			continue
 
 		case flusherCmd = <-vd.flusherCmdChan:


### PR DESCRIPTION
Parts of #279 and might closes that issue.

Changes:
- try forever to reconnect
- limit reconnect attempt time to 1 second (using [DialTimeout](https://golang.org/pkg/net/#DialTimeout))
- add `tlogrpc` to nbdserver config and update the docs
- hot reload `tlogrpc` config
