### PR TITLE
add semideduped storage type

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -386,10 +386,6 @@ type VdiskConfig struct {
 // StorageType returns the type of storage this vdisk uses
 func (cfg *VdiskConfig) StorageType() StorageType {
 	if cfg.Type&propDeduped != 0 {
-		if cfg.Type == VdiskTypeBoot && cfg.RootStorageCluster != "" {
-			return StorageSemiDeduped
-		}
-
 		return StorageDeduped
 	}
 
@@ -535,6 +531,7 @@ const (
 	StorageNil     StorageType = 0
 	StorageDeduped StorageType = 1 << iota
 	StorageNonDeduped
+	// StorageSemiDeduped is not used for now
 	StorageSemiDeduped
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -183,7 +183,7 @@ func (cfg *Config) validateNBD(validRef func(string) error) error {
 
 			// nonDeduped vdisks that support templates,
 			// also require a vdiskID as used on the template storage
-			if vdisk.StorageType() == StorageNondeduped {
+			if vdisk.StorageType() == StorageNonDeduped {
 				if vdisk.RootVdiskID == "" {
 					log.Debugf("defaulting rootVdiskID of vdisk %s to %s", vdiskID, vdiskID)
 					vdisk.RootVdiskID = vdiskID
@@ -386,6 +386,10 @@ type VdiskConfig struct {
 // StorageType returns the type of storage this vdisk uses
 func (cfg *VdiskConfig) StorageType() StorageType {
 	if cfg.Type&propDeduped != 0 {
+		if cfg.Type == VdiskTypeBoot && cfg.RootStorageCluster != "" {
+			return StorageSemiDeduped
+		}
+
 		return StorageDeduped
 	}
 
@@ -396,7 +400,7 @@ func (cfg *VdiskConfig) StorageType() StorageType {
 	// see open issue for more information:
 	// https://github.com/zero-os/0-Disk/issues/222
 
-	return StorageNondeduped
+	return StorageNonDeduped
 }
 
 // TlogSupport returns whether or not the data of this vdisk
@@ -410,7 +414,8 @@ func (cfg *VdiskConfig) TlogSupport() bool {
 // to get the data in case the data isn't available on
 // the normal (local) storage cluster.
 func (cfg *VdiskConfig) TemplateSupport() bool {
-	return cfg.Type&propTemplateSupport != 0
+	return cfg.Type&propTemplateSupport != 0 ||
+		(cfg.Type == VdiskTypeBoot && cfg.RootStorageCluster != "")
 }
 
 // VdiskType represents the type of a vdisk,
@@ -516,10 +521,12 @@ func (st StorageType) String() string {
 	switch st {
 	case StorageDeduped:
 		return "deduped"
-	case StorageNondeduped:
+	case StorageNonDeduped:
 		return "nondeduped"
+	case StorageSemiDeduped:
+		return "semideduped"
 	default:
-		return "Unknown"
+		return "unknown"
 	}
 }
 
@@ -527,7 +534,8 @@ func (st StorageType) String() string {
 const (
 	StorageNil     StorageType = 0
 	StorageDeduped StorageType = 1 << iota
-	StorageNondeduped
+	StorageNonDeduped
+	StorageSemiDeduped
 )
 
 // Vdisk Properties

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -809,12 +809,16 @@ func TestVdiskProperties(t *testing.T) {
 	v := func(t VdiskType) *VdiskConfig {
 		return &VdiskConfig{Type: t}
 	}
+	ve := func(t VdiskType, rootStorageCluster string) *VdiskConfig {
+		return &VdiskConfig{Type: t, RootStorageCluster: rootStorageCluster}
+	}
 
 	// validate storage type property
 	assert.Equal(t, StorageDeduped, v(VdiskTypeBoot).StorageType())
-	assert.Equal(t, StorageNondeduped, v(VdiskTypeDB).StorageType())
-	assert.Equal(t, StorageNondeduped, v(VdiskTypeCache).StorageType())
-	assert.Equal(t, StorageNondeduped, v(VdiskTypeTmp).StorageType())
+	assert.Equal(t, StorageSemiDeduped, ve(VdiskTypeBoot, "foo").StorageType())
+	assert.Equal(t, StorageNonDeduped, v(VdiskTypeDB).StorageType())
+	assert.Equal(t, StorageNonDeduped, v(VdiskTypeCache).StorageType())
+	assert.Equal(t, StorageNonDeduped, v(VdiskTypeTmp).StorageType())
 
 	// validate tlog support
 	assert.True(t, v(VdiskTypeBoot).TlogSupport())

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -809,13 +809,9 @@ func TestVdiskProperties(t *testing.T) {
 	v := func(t VdiskType) *VdiskConfig {
 		return &VdiskConfig{Type: t}
 	}
-	ve := func(t VdiskType, rootStorageCluster string) *VdiskConfig {
-		return &VdiskConfig{Type: t, RootStorageCluster: rootStorageCluster}
-	}
 
 	// validate storage type property
 	assert.Equal(t, StorageDeduped, v(VdiskTypeBoot).StorageType())
-	assert.Equal(t, StorageSemiDeduped, ve(VdiskTypeBoot, "foo").StorageType())
 	assert.Equal(t, StorageNonDeduped, v(VdiskTypeDB).StorageType())
 	assert.Equal(t, StorageNonDeduped, v(VdiskTypeCache).StorageType())
 	assert.Equal(t, StorageNonDeduped, v(VdiskTypeTmp).StorageType())

--- a/nbdserver/ardb/ardb.go
+++ b/nbdserver/ardb/ardb.go
@@ -234,11 +234,21 @@ func newRedisProvider(pool *RedisPool, cfg *config.VdiskClusterConfig) (*redisPr
 	return provider, nil
 }
 
-// redisConnectionProvider defines the interface to get a redis connection,
+// redisDataConnProvider defines the interface to get a redis connection,
 // based on a given index, used by the arbd storage backends
-type redisConnectionProvider interface {
+type redisDataConnProvider interface {
 	RedisConnection(index int64) (conn redis.Conn, err error)
 	FallbackRedisConnection(index int64) (conn redis.Conn, err error)
+}
+
+// redisMetaConnProvider defines the interface to get a redis meta connection.
+type redisMetaConnProvider interface {
+	MetaRedisConnection() (conn redis.Conn, err error)
+}
+
+type redisConnProvider interface {
+	redisDataConnProvider
+	redisMetaConnProvider
 }
 
 // redisProvider allows you to get a redis connection from a pool
@@ -298,7 +308,7 @@ func (rp *redisProvider) FallbackRedisConnection(index int64) (conn redis.Conn, 
 	return
 }
 
-// MetaRedisConnection implements lba.MetaRedisProvider.MetaRedisConnection
+// MetaRedisConnection implements redisMetaConnectionProvider.MetaRedisConnection
 func (rp *redisProvider) MetaRedisConnection() (conn redis.Conn, err error) {
 	rp.mux.RLock()
 	defer rp.mux.RUnlock()

--- a/nbdserver/ardb/bitmap.go
+++ b/nbdserver/ardb/bitmap.go
@@ -1,0 +1,96 @@
+package ardb
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"math/big"
+	"sync"
+)
+
+// newBitMap creates a new bitMap
+func newBitMap() (bm bitMap) {
+	return
+}
+
+// bitMap represents an auto-expanding bitmap,
+// which can be loaded from a string (bytes),
+// as well as created from scratch with a certain amount of memory.
+type bitMap struct {
+	val big.Int
+	mux sync.RWMutex
+}
+
+// Set the bit at the given position
+func (bm *bitMap) Set(pos int) {
+	bm.mux.Lock()
+	defer bm.mux.Unlock()
+
+	bm.val.SetBit(&bm.val, pos, 1)
+}
+
+// Unset the bit at the given position
+func (bm *bitMap) Unset(pos int) {
+	bm.mux.Lock()
+	defer bm.mux.Unlock()
+
+	bm.val.SetBit(&bm.val, pos, 0)
+}
+
+// Test the bit at the given position
+func (bm *bitMap) Test(pos int) bool {
+	bm.mux.RLock()
+	defer bm.mux.RUnlock()
+
+	return bm.val.Bit(pos) == 1
+}
+
+// Bytes returns the bitMap as a byte slice.
+// NOTE that returned content will be gzipped.
+func (bm *bitMap) Bytes() ([]byte, error) {
+	bm.mux.Lock()
+	defer bm.mux.Unlock()
+
+	// get uncompressed bytes
+	input := bm.val.Bytes()
+
+	// prepare gzip compresser
+	var buf bytes.Buffer
+	compr := gzip.NewWriter(&buf)
+
+	// gzip content
+	_, err := compr.Write(input)
+	if err != nil {
+		return nil, err
+	}
+	err = compr.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	// return compressed bytes
+	return buf.Bytes(), nil
+}
+
+// SetBytes as the new internal value of this bit map.
+// NOTE that this method expects the input bytes to be gzipped.
+func (bm *bitMap) SetBytes(b []byte) error {
+	bm.mux.RLock()
+	defer bm.mux.RUnlock()
+
+	decomp, err := gzip.NewReader(bytes.NewReader(b))
+	if err != nil {
+		return err
+	}
+	decomp.Multistream(false)
+	defer decomp.Close()
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, decomp)
+	if err != nil {
+		return err
+	}
+
+	bm.val.SetBytes(buf.Bytes())
+	return nil
+}

--- a/nbdserver/ardb/bitmap_test.go
+++ b/nbdserver/ardb/bitmap_test.go
@@ -1,0 +1,170 @@
+package ardb
+
+import (
+	"testing"
+)
+
+func TestBitMapTest(t *testing.T) {
+	b := newBitMap()
+	b.Set(2)
+	if !b.Test(2) {
+		t.Error("expected true, got false")
+	}
+	if b.Test(3) {
+		t.Error("expected false, got true")
+	}
+	b.Set(3)
+	if !b.Test(3) {
+		t.Error("expected true, got false")
+	}
+
+	if b.Test(8096) {
+		t.Error("expected false, got true")
+	}
+	b.Set(8096)
+	if !b.Test(8096) {
+		t.Error("expected true, got false")
+	}
+}
+
+// Setting a value twice should not unset it.
+func TestBitMapSetTwice(t *testing.T) {
+	b := newBitMap()
+	b.Set(2)
+	if !b.Test(2) {
+		t.Error("expected it to be set")
+	}
+	b.Set(2)
+	if !b.Test(2) {
+		t.Error("expected it to still be set")
+	}
+}
+
+// Unset a value.
+func TestSetUnset(t *testing.T) {
+	b := newBitMap()
+
+	b.Set(2)
+	if !b.Test(2) {
+		t.Error("expected it to be set")
+	}
+	b.Unset(2)
+	if b.Test(2) {
+		t.Error("expected it to be unset")
+	}
+	b.Unset(2)
+	if b.Test(2) {
+		t.Error("expected it to still be unset")
+	}
+}
+
+func TestBitMapBytes(t *testing.T) {
+	one := func(i int) bool {
+		if i < 1024 {
+			return i%2 == 1
+		}
+		if i < 4096 {
+			return i%2 == 0
+		}
+		if i < 10000 {
+			return true
+		}
+		return false
+	}
+
+	b := newBitMap()
+
+	const (
+		l = 12512
+	)
+
+	for i := 0; i < l; i++ {
+		if one(i) {
+			b.Set(i)
+			if !b.Test(i) {
+				t.Errorf("expected %d to be set", i)
+			}
+		} else {
+			b.Unset(i)
+			if b.Test(i) {
+				t.Errorf("expected %d to be unset", i)
+			}
+		}
+	}
+
+	bytes, err := b.Bytes()
+	if err != nil {
+		t.Fatalf("expected Bytes to succeed: %v", err)
+	}
+
+	err = b.SetBytes(bytes)
+	if err != nil {
+		t.Fatalf("expected SetBytes to succeed: %v", err)
+	}
+
+	// test if setting bytes works,
+	// even if bytes were already set
+	for i := 0; i < l; i++ {
+		if one(i) {
+			if !b.Test(i) {
+				t.Errorf("expected %d to be set", i)
+			}
+		} else {
+			if b.Test(i) {
+				t.Errorf("expected %d to be unset", i)
+			}
+		}
+	}
+
+	c := newBitMap()
+	err = c.SetBytes(bytes)
+	if err != nil {
+		t.Fatalf("expected SetBytes to succeed: %v", err)
+	}
+
+	// test if creating from bytes works
+	for i := 0; i < l; i++ {
+		if one(i) {
+			if !c.Test(i) {
+				t.Errorf("expected %d to be set", i)
+			}
+		} else {
+			if c.Test(i) {
+				t.Errorf("expected %d to be unset", i)
+			}
+		}
+	}
+
+	// test if setting a partial bytes map overides everything
+	b = newBitMap()
+	for i := 0; i < 1024; i++ {
+		b.Set(i)
+		if !b.Test(i) {
+			t.Errorf("expected %d to be set", i)
+		}
+	}
+	bytes, err = b.Bytes()
+	if err != nil {
+		t.Fatalf("expected Bytes to succeed: %v", err)
+	}
+
+	err = c.SetBytes(bytes)
+	if err != nil {
+		t.Fatalf("expected SetBytes to succeed: %v", err)
+	}
+
+	one = func(i int) bool {
+		return i < 1024
+	}
+	for i := 0; i < l; i++ {
+		if one(i) {
+			if !c.Test(i) {
+				t.Errorf("expected %d to be set", i)
+			}
+		} else {
+			if c.Test(i) {
+				t.Errorf("expected %d to be unset", i)
+			}
+		}
+	}
+}

--- a/nbdserver/ardb/deduped.go
+++ b/nbdserver/ardb/deduped.go
@@ -12,7 +12,7 @@ import (
 )
 
 // newDedupedStorage returns the deduped backendStorage implementation
-func newDedupedStorage(vdiskID string, blockSize int64, provider redisConnectionProvider, templateSupport bool, vlba *lba.LBA) backendStorage {
+func newDedupedStorage(vdiskID string, blockSize int64, provider redisDataConnProvider, templateSupport bool, vlba *lba.LBA) backendStorage {
 	dedupedStorage := &dedupedStorage{
 		blockSize:       blockSize,
 		vdiskID:         vdiskID,
@@ -39,12 +39,12 @@ func newDedupedStorage(vdiskID string, blockSize int64, provider redisConnection
 // The metadata and data are stored on seperate servers.
 // Accessing data is only ever possible by checking the metadata first.
 type dedupedStorage struct {
-	blockSize       int64                   // block size in bytes
-	vdiskID         string                  // ID of the vdisk
-	zeroContentHash zerodisk.Hash           // a hash of a nil-block of blockSize
-	provider        redisConnectionProvider // used to get a connection to a storage server
-	lba             *lba.LBA                // the LBA used to get/set/modify the metadata (content hashes)
-	getContent      dedupedContentGetter    // getContent function used to get content, is always defined
+	blockSize       int64                 // block size in bytes
+	vdiskID         string                // ID of the vdisk
+	zeroContentHash zerodisk.Hash         // a hash of a nil-block of blockSize
+	provider        redisDataConnProvider // used to get a connection to a storage server
+	lba             *lba.LBA              // the LBA used to get/set/modify the metadata (content hashes)
+	getContent      dedupedContentGetter  // getContent function used to get content, is always defined
 }
 
 // used to provide different content getters based on the vdisk properties

--- a/nbdserver/ardb/deduped_test.go
+++ b/nbdserver/ardb/deduped_test.go
@@ -30,13 +30,13 @@ func copyTestMetaData(t *testing.T, vdiskIDA, vdiskIDB string, providerA, provid
 	}
 	defer connB.Close()
 
-	data, err := redis.StringMap(connA.Do("HGETALL", vdiskIDA))
+	data, err := redis.StringMap(connA.Do("HGETALL", lba.StorageKey(vdiskIDA)))
 	if err != nil {
 		debug.PrintStack()
 		t.Fatal(err)
 	}
 
-	_, err = connB.Do("DEL", vdiskIDB)
+	_, err = connB.Do("DEL", lba.StorageKey(vdiskIDB))
 	if err != nil {
 		debug.PrintStack()
 		t.Fatal(err)
@@ -49,7 +49,7 @@ func copyTestMetaData(t *testing.T, vdiskIDA, vdiskIDB string, providerA, provid
 			return
 		}
 
-		_, err = connB.Do("HSET", vdiskIDB, index, []byte(hash))
+		_, err = connB.Do("HSET", lba.StorageKey(vdiskIDB), index, []byte(hash))
 		if err != nil {
 			debug.PrintStack()
 			t.Fatal(err)

--- a/nbdserver/ardb/nondeduped.go
+++ b/nbdserver/ardb/nondeduped.go
@@ -7,7 +7,7 @@ import (
 )
 
 // newNonDedupedStorage returns the non deduped backendStorage implementation
-func newNonDedupedStorage(vdiskID, rootVdiskID string, blockSize int64, templateSupport bool, provider redisConnectionProvider) backendStorage {
+func newNonDedupedStorage(vdiskID, rootVdiskID string, blockSize int64, templateSupport bool, provider redisDataConnProvider) backendStorage {
 	nondeduped := &nonDedupedStorage{
 		blockSize:      blockSize,
 		storageKey:     NonDedupedStorageKey(vdiskID),
@@ -38,7 +38,7 @@ type nonDedupedStorage struct {
 	rootStorageKey string                  // Storage Key based on rootVdiskID
 	vdiskID        string                  // ID for the vdisk
 	rootVdiskID    string                  // used in case template is supposed (same value as vdiskID if not defined)
-	provider       redisConnectionProvider // used to get the connection info to storage servers
+	provider       redisDataConnProvider   // used to get the connection info to storage servers
 	getContent     nondedupedContentGetter // getter depends on whether there is template support or not
 }
 

--- a/nbdserver/ardb/nondeduped.go
+++ b/nbdserver/ardb/nondeduped.go
@@ -212,5 +212,10 @@ func (ss *nonDedupedStorage) isZeroContent(content []byte) bool {
 // NonDedupedStorageKey returns the storage key that can/will be
 // used to store the nondeduped data for the given vdiskID
 func NonDedupedStorageKey(vdiskID string) string {
-	return "nondedup:" + vdiskID
+	return NonDedupedStorageKeyPrefix + vdiskID
 }
+
+const (
+	// NonDedupedStorageKeyPrefix is the prefix used in NonDedupedStorageKey
+	NonDedupedStorageKeyPrefix = "nondedup:"
+)

--- a/nbdserver/ardb/nondeduped.go
+++ b/nbdserver/ardb/nondeduped.go
@@ -9,10 +9,12 @@ import (
 // newNonDedupedStorage returns the non deduped backendStorage implementation
 func newNonDedupedStorage(vdiskID, rootVdiskID string, blockSize int64, templateSupport bool, provider redisConnectionProvider) backendStorage {
 	nondeduped := &nonDedupedStorage{
-		blockSize:   blockSize,
-		vdiskID:     vdiskID,
-		rootVdiskID: rootVdiskID,
-		provider:    provider,
+		blockSize:      blockSize,
+		storageKey:     NonDedupedStorageKey(vdiskID),
+		rootStorageKey: NonDedupedStorageKey(rootVdiskID),
+		vdiskID:        vdiskID,
+		rootVdiskID:    rootVdiskID,
+		provider:       provider,
 	}
 
 	if templateSupport {
@@ -31,11 +33,13 @@ func newNonDedupedStorage(vdiskID, rootVdiskID string, blockSize int64, template
 // which simply stores each block in redis using
 // a unique key based on the vdiskID and blockIndex.
 type nonDedupedStorage struct {
-	blockSize   int64                   // blocksize in bytes
-	vdiskID     string                  // ID for the vdisk
-	rootVdiskID string                  // used in case template is supposed (same value as vdiskID if not defined)
-	provider    redisConnectionProvider // used to get the connection info to storage servers
-	getContent  nondedupedContentGetter // getter depends on whether there is template support or not
+	blockSize      int64                   // blocksize in bytes
+	storageKey     string                  // Storage Key based on vdiskID
+	rootStorageKey string                  // Storage Key based on rootVdiskID
+	vdiskID        string                  // ID for the vdisk
+	rootVdiskID    string                  // used in case template is supposed (same value as vdiskID if not defined)
+	provider       redisConnectionProvider // used to get the connection info to storage servers
+	getContent     nondedupedContentGetter // getter depends on whether there is template support or not
 }
 
 // used to provide different content getters based on the vdisk properties
@@ -57,12 +61,12 @@ func (ss *nonDedupedStorage) Set(blockIndex int64, content []byte) (err error) {
 		log.Debugf(
 			"deleting content @ %d for vdisk %s as it's an all zeroes block",
 			blockIndex, ss.vdiskID)
-		_, err = conn.Do("HDEL", ss.vdiskID, blockIndex)
+		_, err = conn.Do("HDEL", ss.storageKey, blockIndex)
 		return
 	}
 
 	// content is not zero, so let's (over)write it
-	_, err = conn.Do("HSET", ss.vdiskID, blockIndex, content)
+	_, err = conn.Do("HSET", ss.storageKey, blockIndex, content)
 	return
 }
 
@@ -91,7 +95,7 @@ func (ss *nonDedupedStorage) Merge(blockIndex, offset int64, content []byte) (er
 	defer conn.Close()
 
 	// store new content, as the merged version is non-zero
-	_, err = conn.Do("HSET", ss.vdiskID, blockIndex, mergedContent)
+	_, err = conn.Do("HSET", ss.storageKey, blockIndex, mergedContent)
 	return
 }
 
@@ -111,7 +115,7 @@ func (ss *nonDedupedStorage) Delete(blockIndex int64) (err error) {
 	defer conn.Close()
 
 	// delete the block defined for the block index (if it previously existed at all)
-	_, err = conn.Do("HDEL", ss.vdiskID, blockIndex)
+	_, err = conn.Do("HDEL", ss.storageKey, blockIndex)
 	return
 }
 
@@ -138,7 +142,7 @@ func (ss *nonDedupedStorage) getLocalContent(blockIndex int64) (content []byte, 
 
 	// get block from local data storage server, if it exists at all,
 	// a nil block is returned in case it didn't exist
-	content, err = redisBytes(conn.Do("HGET", ss.vdiskID, blockIndex))
+	content, err = redisBytes(conn.Do("HGET", ss.storageKey, blockIndex))
 	return
 }
 
@@ -162,7 +166,7 @@ func (ss *nonDedupedStorage) getLocalOrRemoteContent(blockIndex int64) (content 
 
 		// get block from local data storage server, if it exists at all,
 		// a nil block is returned in case it didn't exist
-		content, err = redisBytes(conn.Do("HGET", ss.rootVdiskID, blockIndex))
+		content, err = redisBytes(conn.Do("HGET", ss.rootStorageKey, blockIndex))
 		if err != nil {
 			log.Debugf(
 				"content for block %d (vdisk %s) not available in local-, nor in remote storage: %s",
@@ -203,4 +207,10 @@ func (ss *nonDedupedStorage) isZeroContent(content []byte) bool {
 	}
 
 	return true
+}
+
+// NonDedupedStorageKey returns the storage key that can/will be
+// used to store the nondeduped data for the given vdiskID
+func NonDedupedStorageKey(vdiskID string) string {
+	return "nondedup:" + vdiskID
 }

--- a/nbdserver/ardb/nondeduped_test.go
+++ b/nbdserver/ardb/nondeduped_test.go
@@ -26,7 +26,8 @@ func testNondedupContentExists(t *testing.T, memRedis *redisstub.MemoryRedis, vd
 	}
 	defer conn.Close()
 
-	contentReceived, err := redis.Bytes(conn.Do("HGET", vdiskID, blockIndex))
+	storageKey := NonDedupedStorageKey(vdiskID)
+	contentReceived, err := redis.Bytes(conn.Do("HGET", storageKey, blockIndex))
 	if err != nil {
 		debug.PrintStack()
 		t.Fatal(err)
@@ -49,7 +50,8 @@ func testNondedupContentDoesNotExist(t *testing.T, memRedis *redisstub.MemoryRed
 	}
 	defer conn.Close()
 
-	contentReceived, err := redis.Bytes(conn.Do("HGET", vdiskID, blockIndex))
+	storageKey := NonDedupedStorageKey(vdiskID)
+	contentReceived, err := redis.Bytes(conn.Do("HGET", storageKey, blockIndex))
 
 	if err != nil || bytes.Compare(content, contentReceived) != 0 {
 		return

--- a/nbdserver/ardb/semideduped.go
+++ b/nbdserver/ardb/semideduped.go
@@ -228,5 +228,10 @@ func combineErrorPair(e1, e2 error) error {
 // SemiDedupBitMapKey returns the storage key which is used
 // to store the BitMap for the semideduped storage of a given vdisk
 func SemiDedupBitMapKey(vdiskID string) string {
-	return "semidedup:bitmap:" + vdiskID
+	return SemiDedupBitMapKeyPrefix + vdiskID
 }
+
+const (
+	// SemiDedupBitMapKeyPrefix is the prefix used in SemiDedupBitMapKey
+	SemiDedupBitMapKeyPrefix = "semidedup:bitmap:"
+)

--- a/nbdserver/ardb/semideduped.go
+++ b/nbdserver/ardb/semideduped.go
@@ -1,0 +1,144 @@
+package ardb
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/siddontang/go/log"
+	"github.com/zero-os/0-Disk/nbdserver/lba"
+)
+
+func newSemiDedupedStorage(vdiskID string, blockSize int64, provider redisConnectionProvider, vlba *lba.LBA) backendStorage {
+	return &semiDedupedStorage{
+		templateStorage: newDedupedStorage(vdiskID, blockSize, provider, true, vlba),
+		userStorage:     newNonDedupedStorage(vdiskID, "", blockSize, false, provider),
+		blockSize:       blockSize,
+	}
+}
+
+// semiDedupedStorage is a backendStorage implementation,
+// that stores the template content in a local deduped storage,
+// while it stores all user-written (and thus specific) data
+// in the a nondeduped storage, both storages using the same storage servers.
+type semiDedupedStorage struct {
+	// used to store template data
+	// (effectively read-only storage, from a user-perspective)
+	templateStorage backendStorage
+	// used to store user-specific data
+	// e.g. Modified Registers, Applications, ...
+	userStorage backendStorage
+
+	blockSize int64
+}
+
+// Set implements backendStorage.Set
+func (sds *semiDedupedStorage) Set(blockIndex int64, content []byte) error {
+	return sds.userStorage.Set(blockIndex, content)
+}
+
+// Merge implements backendStorage.Merge
+func (sds *semiDedupedStorage) Merge(blockIndex, offset int64, content []byte) error {
+	mergedContent, _ := sds.Get(blockIndex)
+
+	if ocl := int64(len(mergedContent)); ocl == 0 {
+		mergedContent = make([]byte, sds.blockSize)
+	} else if ocl < sds.blockSize {
+		oc := make([]byte, sds.blockSize)
+		copy(oc, mergedContent)
+		mergedContent = oc
+	}
+
+	// copy in new content
+	copy(mergedContent[offset:], content)
+
+	// store new content
+	return sds.userStorage.Set(blockIndex, mergedContent)
+}
+
+// Get implements backendStorage.Get
+func (sds *semiDedupedStorage) Get(blockIndex int64) (content []byte, err error) {
+	// try to get the content as user-specific content,
+	// which has priority, as it is assumed to be newer content
+	content, err = sds.userStorage.Get(blockIndex)
+	if err == nil && content != nil {
+		return
+	}
+	if err != nil {
+		log.Errorf(
+			"semiDedupedStorage received error while gettng user-specific content: %s",
+			err.Error())
+	}
+
+	// otherwise it has to be template-specific content,
+	// if the block index is to be valid at all
+	content, err = sds.templateStorage.Get(blockIndex)
+	return
+}
+
+// Delete implements backendStorage.Delete
+func (sds *semiDedupedStorage) Delete(blockIndex int64) error {
+	tErr := sds.templateStorage.Delete(blockIndex)
+	uErr := sds.userStorage.Delete(blockIndex)
+	return combineErrorPair(tErr, uErr)
+}
+
+// Flush implements backendStorage.Flush
+func (sds *semiDedupedStorage) Flush() error {
+	tErr := sds.templateStorage.Flush()
+	uErr := sds.userStorage.Flush()
+	return combineErrorPair(tErr, uErr)
+}
+
+// Close implements backendStorage.Close
+func (sds *semiDedupedStorage) Close() error {
+	tErr := sds.templateStorage.Close()
+	uErr := sds.userStorage.Close()
+	return combineErrorPair(tErr, uErr)
+}
+
+// GoBackground implements backendStorage.GoBackground
+func (sds *semiDedupedStorage) GoBackground(ctx context.Context) {
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// start template-data background goroutine
+	go func() {
+		defer wg.Done()
+		sds.templateStorage.GoBackground(ctx)
+	}()
+
+	// start user-data background goroutine
+	go func() {
+		defer wg.Done()
+		sds.userStorage.GoBackground(ctx)
+	}()
+
+	wait := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(wait)
+	}()
+
+	// wait for both background threads to be done
+	// OR until shared context is done
+	select {
+	case <-wait:
+		return
+
+	case <-ctx.Done():
+		return
+	}
+}
+
+func combineErrorPair(e1, e2 error) error {
+	if e1 == nil {
+		return e2
+	}
+
+	if e2 == nil {
+		return e1
+	}
+
+	return fmt.Errorf("%v; %v", e1, e2)
+}

--- a/nbdserver/ardb/semideduped_test.go
+++ b/nbdserver/ardb/semideduped_test.go
@@ -1,0 +1,185 @@
+package ardb
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbdserver/lba"
+	"github.com/zero-os/0-Disk/redisstub"
+)
+
+func createTestSemiDedupedStorage(t *testing.T, vdiskID string, blockSize, blockCount int64, provider *testRedisProvider) backendStorage {
+	lba, err := lba.NewLBA(
+		vdiskID,
+		blockCount,
+		DefaultLBACacheLimit,
+		provider)
+	if err != nil {
+		t.Fatal("couldn't create LBA", err)
+	}
+
+	return newSemiDedupedStorage(vdiskID, blockSize, provider, lba)
+}
+
+func TestSemiDedupedContentBasic(t *testing.T) {
+	const (
+		templateIndexA = 0
+		templateIndexB = 1
+
+		blockSize  = 8
+		blockCount = 8
+	)
+	var (
+		templateContentA = []byte{1, 2, 3, 4, 5, 6, 7, 8}
+		templateContentB = []byte{8, 7, 6, 5, 4, 3, 2, 1}
+	)
+	templateRedis := func() *redisstub.MemoryRedis {
+		memRedis := redisstub.NewMemoryRedis()
+		go func() {
+			defer memRedis.Close()
+			memRedis.Listen()
+		}()
+
+		redisProvider := newTestRedisProvider(memRedis, nil) // root = nil
+		template := createTestDedupedStorage(t, "template", blockSize, blockCount, false, redisProvider)
+		if template == nil {
+			t.Fatal("template is nil")
+		}
+
+		err := template.Set(templateIndexA, templateContentA[:])
+		if err != nil {
+			t.Fatalf("setting templateIndexA failed: %v", err)
+		}
+
+		err = template.Set(templateIndexB, templateContentB[:])
+		if err != nil {
+			t.Fatalf("setting templateIndexB failed: %v", err)
+		}
+
+		err = template.Flush()
+		if err != nil {
+			t.Fatalf("flushing template failed: %v", err)
+		}
+
+		return memRedis
+	}()
+	if templateRedis == nil {
+		t.Fatal("templateRedis is nil")
+	}
+
+	memRedis := redisstub.NewMemoryRedis()
+	go func() {
+		defer memRedis.Close()
+		memRedis.Listen()
+	}()
+	redisProvider := newTestRedisProvider(memRedis, templateRedis)
+
+	copyTestMetaData(t, "template", "a",
+		newTestRedisProvider(templateRedis, nil),
+		redisProvider)
+
+	storage := createTestSemiDedupedStorage(t, "a", blockSize, blockCount, redisProvider)
+	if storage == nil {
+		t.Fatal("storage is nil")
+	}
+
+	const (
+		userIndexA = 3
+	)
+	var (
+		userContentA = []byte{4, 2}
+	)
+
+	// set some user content
+	err := storage.Set(userIndexA, userContentA)
+	if err != nil {
+		t.Fatalf("setting userIndexA failed: %v", err)
+	}
+	// get that user content
+	content, err := storage.Get(userIndexA)
+	if err != nil {
+		t.Fatalf("getting userIndexA failed: %v", err)
+	}
+	if bytes.Compare(userContentA, content[:2]) != 0 {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+
+	// try to get template content A
+	content, err = storage.Get(templateIndexA)
+	if err != nil {
+		t.Fatalf("getting templateIndexA failed: %v", err)
+	}
+	if bytes.Compare(templateContentA, content) != 0 {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+
+	// try to get template content B
+	content, err = storage.Get(templateIndexB)
+	if err != nil {
+		t.Fatalf("getting templateIndexB failed: %v", err)
+	}
+	if bytes.Compare(templateContentB, content) != 0 {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+
+	// overwrite template content B
+	err = storage.Set(templateIndexB, userContentA)
+	if err != nil {
+		t.Fatalf("setting templateIndexB failed: %v", err)
+	}
+	// and ensure that content is indeed set
+	content, err = storage.Get(templateIndexB)
+	if err != nil {
+		t.Fatalf("getting templateIndexB failed: %v", err)
+	}
+	if bytes.Compare(userContentA, content[:2]) != 0 {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+
+	// delete content
+	err = storage.Delete(templateIndexB)
+	if err != nil {
+		t.Fatalf("deleting templateIndexB failed: %v", err)
+	}
+	// and ensure that content is indeed deleted
+	content, err = storage.Get(templateIndexB)
+	if err != nil {
+		t.Fatalf("getting templateIndexB failed: %v", err)
+	}
+	if content != nil {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+
+	// let's merge template with user content
+	err = storage.Merge(templateIndexA, 1, userContentA)
+	if err != nil {
+		t.Fatalf("merging templateIndexA failed: %v", err)
+	}
+	// let's check if the merging went fine
+	content, err = storage.Get(templateIndexA)
+	if err != nil {
+		t.Fatalf("getting templateIndexA failed: %v", err)
+	}
+	if bytes.Compare([]byte{1, 4, 2, 4, 5, 6, 7, 8}, content) != 0 {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+
+	// let's merge nil content with user content
+	err = storage.Merge(templateIndexB, 2, userContentA)
+	if err != nil {
+		t.Fatalf("merging templateIndexB failed: %v", err)
+	}
+	// let's check if the merging went fine
+	content, err = storage.Get(templateIndexB)
+	if err != nil {
+		t.Fatalf("getting templateIndexB failed: %v", err)
+	}
+	if bytes.Compare([]byte{0, 0, 4, 2, 0, 0, 0, 0}, content) != 0 {
+		t.Fatalf("unexpected content found: %v", content)
+	}
+}
+
+func init() {
+	log.SetLevel(log.DebugLevel)
+}

--- a/nbdserver/ardb/semideduped_test.go
+++ b/nbdserver/ardb/semideduped_test.go
@@ -101,7 +101,7 @@ func TestSemiDedupedContentBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getting userIndexA failed: %v", err)
 	}
-	if bytes.Compare(userContentA, content[:2]) != 0 {
+	if len(content) < 2 || bytes.Compare(userContentA, content[:2]) != 0 {
 		t.Fatalf("unexpected content found: %v", content)
 	}
 
@@ -133,7 +133,7 @@ func TestSemiDedupedContentBasic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getting templateIndexB failed: %v", err)
 	}
-	if bytes.Compare(userContentA, content[:2]) != 0 {
+	if len(content) < 2 || bytes.Compare(userContentA, content[:2]) != 0 {
 		t.Fatalf("unexpected content found: %v", content)
 	}
 

--- a/nbdserver/lba/lba.go
+++ b/nbdserver/lba/lba.go
@@ -315,5 +315,10 @@ func (e flushError) Error() (s string) {
 // StorageKey returns the storage key that can/will be
 // used to store the LBA data for the given vdiskID
 func StorageKey(vdiskID string) string {
-	return "lba:" + vdiskID
+	return StorageKeyPrefix + vdiskID
 }
+
+const (
+	// StorageKeyPrefix is the prefix used in StorageKey
+	StorageKeyPrefix = "lba:"
+)

--- a/zeroctl/cmd/copyvdisk/deduped.go
+++ b/zeroctl/cmd/copyvdisk/deduped.go
@@ -10,8 +10,6 @@ import (
 )
 
 func copyDedupedSameConnection(sourceID, targetID string, conn redis.Conn) (err error) {
-	defer conn.Close()
-
 	script := redis.NewScript(0, `
 local source = ARGV[1]
 local destination = ARGV[2]
@@ -42,11 +40,6 @@ return redis.call("HLEN", destination)
 }
 
 func copyDedupedDifferentConnections(sourceID, targetID string, connA, connB redis.Conn) (err error) {
-	defer func() {
-		connA.Close()
-		connB.Close()
-	}()
-
 	sourceKey, targetKey := lba.StorageKey(sourceID), lba.StorageKey(targetID)
 
 	// get data from source connection

--- a/zeroctl/cmd/copyvdisk/nondeduped.go
+++ b/zeroctl/cmd/copyvdisk/nondeduped.go
@@ -9,9 +9,7 @@ import (
 	"github.com/zero-os/0-Disk/nbdserver/ardb"
 )
 
-func copyNondedupedSameConnection(sourceID, targetID string, conn redis.Conn) (err error) {
-	defer conn.Close()
-
+func copyNonDedupedSameConnection(sourceID, targetID string, conn redis.Conn) (err error) {
 	script := redis.NewScript(0, `
 local source = ARGV[1]
 local destination = ARGV[2]
@@ -44,12 +42,7 @@ return redis.call("HLEN", destination)
 	return
 }
 
-func copyNondedupedDifferentConnections(sourceID, targetID string, connA, connB redis.Conn) (err error) {
-	defer func() {
-		connA.Close()
-		connB.Close()
-	}()
-
+func copyNonDedupedDifferentConnections(sourceID, targetID string, connA, connB redis.Conn) (err error) {
 	sourceKey := ardb.NonDedupedStorageKey(sourceID)
 	targetKey := ardb.NonDedupedStorageKey(targetID)
 

--- a/zeroctl/cmd/copyvdisk/semideduped.go
+++ b/zeroctl/cmd/copyvdisk/semideduped.go
@@ -1,0 +1,64 @@
+package copyvdisk
+
+import (
+	"github.com/garyburd/redigo/redis"
+	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbdserver/ardb"
+)
+
+// NOTE: copies bitmask only
+func copySemiDedupedSameConnection(sourceID, targetID string, conn redis.Conn) (hasBitMask bool, err error) {
+	script := redis.NewScript(0, `
+local source = ARGV[1]
+local destination = ARGV[2]
+
+if redis.call("EXISTS", source) == 0 then
+    return 0
+end
+
+if redis.call("EXISTS", destination) == 1 then
+    redis.call("DEL", destination)
+end
+
+redis.call("RESTORE", destination, 0, redis.call("DUMP", source))
+return 1
+`)
+
+	log.Infof("dumping vdisk %q's bitmask and restoring it as vdisk %q's bitmask",
+		sourceID, targetID)
+
+	sourceKey := ardb.SemiDedupBitMapKey(sourceID)
+	targetKey := ardb.SemiDedupBitMapKey(targetID)
+
+	hasBitMask, err = redis.Bool(script.Do(conn, sourceKey, targetKey))
+	return
+}
+
+// NOTE: copies bitmask only
+func copySemiDedupedDifferentConnections(sourceID, targetID string, connA, connB redis.Conn) (hasBitMask bool, err error) {
+	sourceKey := ardb.SemiDedupBitMapKey(sourceID)
+
+	log.Infof("collecting semidedup bitmask from source vdisk %q...", sourceID)
+	bytes, err := redis.Bytes(connA.Do("GET", sourceKey))
+	if err == redis.ErrNil {
+		err = nil
+		log.Infof("no semidedup bitmask found for source vdisk %q...", sourceID)
+		return // nothing to do, as there is no bitmask
+	}
+	if err != nil {
+		return // couldn't get bitmask due to an unexpected error
+	}
+
+	log.Infof("collected semidedup bitmask from source vdisk %q...", sourceID)
+
+	targetKey := ardb.SemiDedupBitMapKey(targetID)
+	_, err = connB.Do("SET", targetKey, bytes)
+	if err != nil {
+		return // couldn't set bitmask, this makes the vdisk invalid
+	}
+
+	log.Infof("stored semidedup bitmask for target vdisk %q...", targetID)
+
+	hasBitMask = true
+	return
+}

--- a/zeroctl/cmd/copyvdisk/vdisk.go
+++ b/zeroctl/cmd/copyvdisk/vdisk.go
@@ -74,7 +74,7 @@ func copyVdisk(cmd *cobra.Command, args []string) error {
 			sourceVdiskID, targetVdiskID,
 			cfg.StorageClusters[sourceVdisk.StorageCluster],
 			cfg.StorageClusters[targetStorageCluster])
-	case config.StorageNondeduped:
+	case config.StorageNonDeduped:
 		return copyNondedupedVdisk(
 			sourceVdiskID, targetVdiskID,
 			cfg.StorageClusters[sourceVdisk.StorageCluster],

--- a/zeroctl/cmd/copyvdisk/vdisk.go
+++ b/zeroctl/cmd/copyvdisk/vdisk.go
@@ -75,7 +75,12 @@ func copyVdisk(cmd *cobra.Command, args []string) error {
 			cfg.StorageClusters[sourceVdisk.StorageCluster],
 			cfg.StorageClusters[targetStorageCluster])
 	case config.StorageNonDeduped:
-		return copyNondedupedVdisk(
+		return copyNonDedupedVdisk(
+			sourceVdiskID, targetVdiskID,
+			cfg.StorageClusters[sourceVdisk.StorageCluster],
+			cfg.StorageClusters[targetStorageCluster])
+	case config.StorageSemiDeduped:
+		return copySemiDedupedVdisk(
 			sourceVdiskID, targetVdiskID,
 			cfg.StorageClusters[sourceVdisk.StorageCluster],
 			cfg.StorageClusters[targetStorageCluster])
@@ -100,6 +105,7 @@ func copyDedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster co
 		if err != nil {
 			return fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
 		}
+		defer conn.Close()
 
 		return copyDedupedSameConnection(sourceID, targetID, conn)
 	}
@@ -110,12 +116,16 @@ func copyDedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster co
 	if err != nil {
 		return fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
 	}
+	defer func() {
+		connA.Close()
+		connB.Close()
+	}()
 
 	return copyDedupedDifferentConnections(sourceID, targetID, connA, connB)
 }
 
 // NOTE: copies data only (as there is no metadata for nondeduped vdisks)
-func copyNondedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster config.StorageClusterConfig) error {
+func copyNonDedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster config.StorageClusterConfig) error {
 	sourceDataServerCount := len(sourceCluster.DataStorage)
 	targetDataServerCount := len(targetCluster.DataStorage)
 
@@ -140,11 +150,9 @@ func copyNondedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster
 			if err != nil {
 				return fmt.Errorf("couldn't connect to data ardb: %s", err.Error())
 			}
+			defer conn.Close()
 
-			err = copyNondedupedSameConnection(sourceID, targetID, conn)
-			if err != nil {
-				return err
-			}
+			return copyNonDedupedSameConnection(sourceID, targetID, conn)
 		}
 
 		// between different storage servers
@@ -152,13 +160,96 @@ func copyNondedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster
 		if err != nil {
 			return fmt.Errorf("couldn't connect to data ardb: %s", err.Error())
 		}
+		defer func() {
+			connA.Close()
+			connB.Close()
+		}()
 
-		err = copyNondedupedDifferentConnections(sourceID, targetID, connA, connB)
+		err = copyNonDedupedDifferentConnections(sourceID, targetID, connA, connB)
 		if err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+func copySemiDedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster config.StorageClusterConfig) error {
+	if sourceCluster.MetadataStorage == nil {
+		return errors.New("no metaDataServer given for source")
+	}
+	if targetCluster.MetadataStorage == nil {
+		return errors.New("no metaDataServer given for target")
+	}
+
+	var hasBitMask bool
+	var err error
+
+	// within same meta storage server
+	if *sourceCluster.MetadataStorage == *targetCluster.MetadataStorage {
+		// copy metadata from the same storage server
+		hasBitMask, err = func() (hasBitMask bool, err error) {
+			conn, err := getConnection(*sourceCluster.MetadataStorage)
+			if err != nil {
+				err = fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+				return
+			}
+			defer conn.Close()
+
+			// copy metadata of deduped metadata
+			err = copyDedupedSameConnection(sourceID, targetID, conn)
+			if err != nil {
+				err = fmt.Errorf("couldn't copy deduped metadata: %s", err.Error())
+				return
+			}
+
+			// copy bitmask
+			hasBitMask, err = copySemiDedupedSameConnection(sourceID, targetID, conn)
+			return
+		}()
+	} else {
+		// copy metadata from different storage servers
+		hasBitMask, err = func() (hasBitMask bool, err error) {
+			connA, connB, err := getConnections(*sourceCluster.MetadataStorage, *targetCluster.MetadataStorage)
+			if err != nil {
+				err = fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+				return
+			}
+			defer func() {
+				connA.Close()
+				connB.Close()
+			}()
+
+			// copy metadata of deduped metadata
+			err = copyDedupedDifferentConnections(sourceID, targetID, connA, connB)
+			if err != nil {
+				err = fmt.Errorf("couldn't copy deduped metadata: %s", err.Error())
+				return
+			}
+
+			// copy bitmask
+			hasBitMask, err = copySemiDedupedDifferentConnections(sourceID, targetID, connA, connB)
+			return
+		}()
+	}
+
+	if err != nil {
+		return fmt.Errorf("couldn't copy bitmask: %v", err)
+	}
+	if !hasBitMask {
+		// no bitmask == no nondeduped content,
+		// which means this is an untouched semideduped storage
+		return nil // nothing to do, early return
+	}
+
+	// dispatch the rest of the work to the copyNonDedupedVdisk func,
+	// to copy all the user (nondeduped) data
+	err = copyNonDedupedVdisk(sourceID, targetID, sourceCluster, targetCluster)
+	if err != nil {
+		return fmt.Errorf("couldn't copy nondeduped content: %v", err)
+	}
+
+	// copy went ALL-OK!
 	return nil
 }
 
@@ -188,6 +279,9 @@ func init() {
 If no target storage cluster is given,
 the storage cluster configured for the source vdisk
 will also be used for the target vdisk.
+
+If an error occured, the target vdisk should be considered as non-existent,
+even though data which is already copied is not rolled back.
 
 NOTE: by design,
   only the metadata of a deduped vdisk is copied,

--- a/zeroctl/cmd/delvdisk/deduped.go
+++ b/zeroctl/cmd/delvdisk/deduped.go
@@ -6,6 +6,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbdserver/lba"
 )
 
 // delete the metadata of deduped vdisks
@@ -26,7 +27,7 @@ func deleleDedupedVdisksMetadata(force bool, cfg config.StorageServerConfig, vdi
 	var delVdisks []string
 	for _, vdiskID := range vdiskids {
 		log.Infof("deleting metadata of vdisk %s...", vdiskID)
-		err := conn.Send("DEL", vdiskID)
+		err := conn.Send("DEL", lba.StorageKey(vdiskID))
 		if err != nil {
 			if !force {
 				return err

--- a/zeroctl/cmd/delvdisk/deduped.go
+++ b/zeroctl/cmd/delvdisk/deduped.go
@@ -4,65 +4,46 @@ import (
 	"fmt"
 
 	"github.com/garyburd/redigo/redis"
-	"github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbdserver/lba"
 )
 
-// delete the metadata of deduped vdisks
-func deleleDedupedVdisksMetadata(force bool, cfg config.StorageServerConfig, vdiskids ...string) error {
-	if len(vdiskids) == 0 {
-		return nil // no vdisks to delete, returning early
-	}
+func newDedupDelController(vdiskID string) delController {
+	return &dedupDelController{vdiskID}
+}
 
-	// open redis connection
-	log.Infof("dialing redis TCP connection at: %s (%d)", cfg.Address, cfg.Database)
-	conn, err := redis.Dial("tcp", cfg.Address, redis.DialDatabase(cfg.Database))
+// dedupDelController defines a delController implementation
+// which can be used to delete the metadata for deduped content
+type dedupDelController struct {
+	vdiskID string
+}
+
+// BatchRequest implements delController.BatchRequest
+func (c dedupDelController) BatchRequest(conn redis.Conn) error {
+	log.Infof("deleting deduped metadata of vdisk %s...", c.vdiskID)
+	err := conn.Send("DEL", lba.StorageKey(c.vdiskID))
 	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	// add each delete request to the pipeline
-	var delVdisks []string
-	for _, vdiskID := range vdiskids {
-		log.Infof("deleting metadata of vdisk %s...", vdiskID)
-		err := conn.Send("DEL", lba.StorageKey(vdiskID))
-		if err != nil {
-			if !force {
-				return err
-			}
-			log.Error("could not delete metadata of deduped vdisk: ", vdiskID)
-			continue
-		}
-		delVdisks = append(delVdisks, vdiskID)
-	}
-
-	// flush all delete requests
-	err = conn.Flush()
-	if err != nil {
-		return fmt.Errorf("could not delete metadata of deduped vdisks %v: %s", delVdisks, err.Error())
-	}
-
-	// check if all vdisks have actually been deleted
-	for _, vdiskID := range delVdisks {
-		deleted, err := redis.Bool(conn.Receive())
-		if err != nil {
-			if !force {
-				return err
-			}
-
-			log.Errorf("could not delete metadata of deduped vdisk %s: %s", vdiskID, err.Error())
-			continue
-		}
-
-		// it's not an error if it did not exist yet,
-		// as this is possible due to the multiple ardbs in use
-		if !deleted {
-			log.Infof("could not delete metadata of deduped vdisk %s: did not exist at %s (%d)",
-				vdiskID, cfg.Address, cfg.Database)
-		}
+		return c.error(err)
 	}
 
 	return nil
+}
+
+// CheckRequest implements delController.CheckRequest
+func (c dedupDelController) CheckRequest(conn redis.Conn) error {
+	deleted, err := redis.Bool(conn.Receive())
+	if err != nil {
+		return c.error(err)
+	}
+	if deleted {
+		return nil
+	}
+
+	return noDeleteError(fmt.Errorf(
+		"no deduped metadata existed for vdisk %s", c.vdiskID))
+}
+
+func (c dedupDelController) error(err error) error {
+	return fmt.Errorf("could not delete metadata of deduped content for vdisk %s: %s",
+		c.vdiskID, err.Error())
 }

--- a/zeroctl/cmd/delvdisk/nondeduped.go
+++ b/zeroctl/cmd/delvdisk/nondeduped.go
@@ -6,6 +6,7 @@ import (
 	"github.com/garyburd/redigo/redis"
 	"github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbdserver/ardb"
 )
 
 // delete the data of nondeduped vdisks
@@ -26,7 +27,7 @@ func deleleNondedupedVdisks(force bool, cfg config.StorageServerConfig, vdiskids
 	var delVdisks []string
 	for _, vdiskID := range vdiskids {
 		log.Infof("deleting data of nondeduped vdisk %s...", vdiskID)
-		err := conn.Send("DEL", vdiskID)
+		err := conn.Send("DEL", ardb.NonDedupedStorageKey(vdiskID))
 		if err != nil {
 			if !force {
 				return err

--- a/zeroctl/cmd/delvdisk/semideduped.go
+++ b/zeroctl/cmd/delvdisk/semideduped.go
@@ -1,0 +1,49 @@
+package delvdisk
+
+import (
+	"fmt"
+
+	"github.com/garyburd/redigo/redis"
+	"github.com/siddontang/go/log"
+	"github.com/zero-os/0-Disk/nbdserver/ardb"
+)
+
+func newSemiDedupDelController(vdiskID string) delController {
+	return &semiDedupDelController{vdiskID}
+}
+
+// semiDedupDelController defines a delController implementation
+// which can be used to delete the data for nondeduped content
+type semiDedupDelController struct {
+	vdiskID string
+}
+
+// BatchRequest implements delController.BatchRequest
+func (c semiDedupDelController) BatchRequest(conn redis.Conn) error {
+	log.Infof("deleting storage bitmap of semi deduped vdisk %s...", c.vdiskID)
+	err := conn.Send("DEL", ardb.SemiDedupBitMapKey(c.vdiskID))
+	if err != nil {
+		return c.error(err)
+	}
+
+	return nil
+}
+
+// CheckRequest implements delController.CheckRequest
+func (c semiDedupDelController) CheckRequest(conn redis.Conn) error {
+	deleted, err := redis.Bool(conn.Receive())
+	if err != nil {
+		return c.error(err)
+	}
+	if deleted {
+		return nil
+	}
+
+	return noDeleteError(fmt.Errorf(
+		"no storage bitmap existed for semi deduped vdisk %s", c.vdiskID))
+}
+
+func (c semiDedupDelController) error(err error) error {
+	return fmt.Errorf("could not delete storage bitmap for semi deduped vdisk %s: %s",
+		c.vdiskID, err.Error())
+}

--- a/zeroctl/cmd/delvdisk/vdisks.go
+++ b/zeroctl/cmd/delvdisk/vdisks.go
@@ -61,7 +61,7 @@ func deleteVdisks(cmd *cobra.Command, args []string) error {
 			vdiskids = dedupedVdisksMetadata[*cluster.MetadataStorage]
 			dedupedVdisksMetadata[*cluster.MetadataStorage] = append(vdiskids, vdiskID)
 
-		case config.StorageNondeduped:
+		case config.StorageNonDeduped:
 			for _, storage := range cluster.DataStorage {
 				vdiskids = nondedupedVdisks[storage]
 				nondedupedVdisks[storage] = append(vdiskids, vdiskID)

--- a/zeroctl/cmd/delvdisk/vdisks.go
+++ b/zeroctl/cmd/delvdisk/vdisks.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/garyburd/redigo/redis"
 	"github.com/spf13/cobra"
 	"github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/log"
@@ -41,13 +42,11 @@ func deleteVdisks(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// store all deduped and nondeduped vdisks
-	// in a map, where the map-key is the ardb's connection if
-	// and the values are the ids of the vdisks stored on that connection string
-	dedupedVdisksMetadata := make(map[config.StorageServerConfig][]string)
-	nondedupedVdisks := make(map[config.StorageServerConfig][]string)
+	// store all requests in a map, sorted per storage server,
+	// such that we only require 1 delete pipeline per storage server.
+	delControllerMap := make(map[config.StorageServerConfig][]delController)
 
-	var vdiskids []string
+	var storage config.StorageServerConfig
 	var storageType config.StorageType
 
 	log.Info("sorting all target vdisks by storage type and connection")
@@ -56,15 +55,29 @@ func deleteVdisks(cmd *cobra.Command, args []string) error {
 		cluster := cfg.StorageClusters[vdisk.StorageCluster]
 
 		switch storageType = vdisk.StorageType(); storageType {
+		// add deduped delete controllers
 		case config.StorageDeduped:
-			// metadataStorage is guaranteed to exist for deduped storage
-			vdiskids = dedupedVdisksMetadata[*cluster.MetadataStorage]
-			dedupedVdisksMetadata[*cluster.MetadataStorage] = append(vdiskids, vdiskID)
+			storage = *cluster.MetadataStorage
+			delControllerMap[storage] = append(
+				delControllerMap[storage], newDedupDelController(vdiskID))
 
+		// add non deduped delete controllers
 		case config.StorageNonDeduped:
-			for _, storage := range cluster.DataStorage {
-				vdiskids = nondedupedVdisks[storage]
-				nondedupedVdisks[storage] = append(vdiskids, vdiskID)
+			for _, storage = range cluster.DataStorage {
+				delControllerMap[storage] = append(
+					delControllerMap[storage], newNonDedupDelController(vdiskID))
+			}
+
+		// add semi deduped delete controllers
+		case config.StorageSemiDeduped:
+			storage = *cluster.MetadataStorage
+			delControllerMap[storage] = append(
+				delControllerMap[storage],
+				newDedupDelController(vdiskID), newSemiDedupDelController(vdiskID))
+
+			for _, storage = range cluster.DataStorage {
+				delControllerMap[storage] = append(
+					delControllerMap[storage], newNonDedupDelController(vdiskID))
 			}
 
 		default: // shouldn't happen
@@ -73,23 +86,14 @@ func deleteVdisks(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	if len(dedupedVdisksMetadata) > 0 {
-		log.Info("deleting metadata of selected deduped vdisks...")
-		for cfg, vdiskids := range dedupedVdisksMetadata {
-			err = deleleDedupedVdisksMetadata(vdisksCfg.Force, cfg, vdiskids...)
-			if err != nil {
+	for cfg, controllers := range delControllerMap {
+		err = deleleFromStorageServer(vdisksCfg.Force, cfg, controllers...)
+		if err != nil {
+			if !vdisksCfg.Force {
 				return err
 			}
-		}
-	}
 
-	if len(nondedupedVdisks) > 0 {
-		log.Info("deleting data of selected nondeduped vdisks...")
-		for cfg, vdiskids := range nondedupedVdisks {
-			err = deleleNondedupedVdisks(vdisksCfg.Force, cfg, vdiskids...)
-			if err != nil {
-				return err
-			}
+			log.Error(err)
 		}
 	}
 
@@ -149,6 +153,83 @@ func getVdisks(cfg *config.Config, args []string) (map[string]config.VdiskConfig
 
 	return vdisks, nil
 }
+
+// delete the semideduped vdisks
+func deleleFromStorageServer(force bool, cfg config.StorageServerConfig, controllers ...delController) error {
+	if len(controllers) == 0 {
+		return nil // no controllers defined, returning early
+	}
+
+	// open redis connection
+	log.Infof("dialing redis TCP connection at: %s (%d)", cfg.Address, cfg.Database)
+	conn, err := redis.Dial("tcp", cfg.Address, redis.DialDatabase(cfg.Database))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// add each delete request to the pipeline
+	var batchedControllers []delController
+	for _, controller := range controllers {
+		err = controller.BatchRequest(conn)
+		if err != nil {
+			if !force {
+				return err
+			}
+
+			log.Error(err)
+			continue
+		}
+		batchedControllers = append(batchedControllers, controller)
+	}
+
+	// flush all delete requests
+	err = conn.Flush()
+	if err != nil {
+		return fmt.Errorf("could not flush request for conn %s (%d): %v",
+			cfg.Address, cfg.Database, err)
+	}
+
+	// check if all delete operations were successfull
+	for _, controller := range batchedControllers {
+		err = controller.CheckRequest(conn)
+		// content was deleted, no error, Yay!
+		if err == nil {
+			continue
+		}
+
+		// no critical error, content simply didn't exist, so couldn't be deleted
+		if err, ok := err.(noDeleteError); ok {
+			log.Infof("%v: did not exist at %s (%d)", err, cfg.Address, cfg.Database)
+			continue
+		}
+
+		// critical error while deleting content
+
+		if !force {
+			return err
+		}
+
+		log.Error(err)
+	}
+
+	return nil
+}
+
+// delController is a generic interface, which allows us to batch & check
+// a deletion request, pipelined in a series of deletion processes
+// for a single storage server.
+type delController interface {
+	// BatchRequest adds the request to the conn's pipeline
+	BatchRequest(conn redis.Conn) error
+	// CheckRequest checks if the earlier batch request has been processed fine
+	CheckRequest(conn redis.Conn) error
+}
+
+// noDeleteError can be returned by delController.CheckRequest,
+// in case there was no real error, but nothing got deleted either,
+// probably because it didn't exist
+type noDeleteError error
 
 func init() {
 	VdisksCmd.Long = VdisksCmd.Short + `


### PR DESCRIPTION
+ fixes #298;
+ fixes #326;

**warning**: this does contain breaking changes. As the storage key for LBA data and nondeduped data are now prefixed, such as to prevent name collisions between the two, when stored on the same storage server. As we're still in alpha, this shouldn't matter though, as it's not the first time we introduce breaking changes in an alpha release.