### PR TITLE
improve code base and inline docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Components:
   - A network block device server to expose the vdisks to virtual machines
 * [TLOG Server](tlog/)
   - A transaction log server to record block changes
-* [Command Line Tool](g8stor/)
+* [zeroctl](zeroctl/)
   - A command line tool to control vdisks
 
 Make sure to have [Golang](https://golang.org/) version 1.8 or above installed.
 
 ## More
 
-All documentation is in the [`/docs`](./docs) directory, including a [table of contents](/docs/SUMMARY.md).
+All documentation is in the [`/docs`](docs/) directory, including a [table of contents](/docs/SUMMARY.md).
 
 In [Getting Started with NBD Server](/docs/gettingstarted/gettingstarted.md) you find the recommended path to quickly get up and running.

--- a/gonbdserver/nbd/protocol.go
+++ b/gonbdserver/nbd/protocol.go
@@ -4,7 +4,8 @@ package nbd
 
 // this section is in essence a transcription of the protocol from
 // NBD's proto.md. For details of
-// what the options mean, see proto.md
+// what the options mean, see proto.md at
+// https://github.com/NetworkBlockDevice/nbd/blob/master/doc/proto.md
 
 // NBD commands
 const (

--- a/hash.go
+++ b/hash.go
@@ -38,5 +38,5 @@ func (h Hash) Equals(compareTo Hash) bool {
 
 //Bytes returns the hash as a slice of bytes
 func (h Hash) Bytes() []byte {
-	return h[:]
+	return h
 }

--- a/log/handler.go
+++ b/log/handler.go
@@ -40,6 +40,9 @@ func FileHandler(path string) (Handler, error) {
 
 // SyslogHandler opens a connection to the system syslog daemon
 // by calling syslog.New and writes all records to it.
+//
+// WARNING: this function has never been tested,
+// consequently it is unknown if its behavior is actually working.
 func SyslogHandler(tag string) (Handler, error) {
 	handler, err := log.SyslogHandler(syslog.LOG_KERN, tag, log.LogfmtFormat())
 	if err != nil {
@@ -51,7 +54,10 @@ func SyslogHandler(tag string) (Handler, error) {
 
 // EmailHandler returns a handler which sends an email to the
 // given email address in case a logged record is of the
-// specified minimum level
+// specified minimum level.
+//
+// WARNING: this function has never been tested,
+// consequently it is unknown if its behavior is actually working.
 func EmailHandler(minLevel Level, module string, to []string, from, smtp string, auth smtp.Auth) (Handler, error) {
 	if auth == nil {
 		return nil, errors.New("EmailHandler requires a valid and non-nil smtp Auth object")
@@ -180,6 +186,11 @@ func callerFileLog15Handler(callDepth int, h log.Handler) log.Handler {
 	})
 }
 
+// newLoggerHandler creates a new log handler.
+// the specified level and above defines what is to be logged,
+// the extraStackDepth ensures the correct file-source is attached to each log,
+// and optionally handlers can defined.
+// If no handlers are defined, the StderrHandler is used.
 func newLoggerHandler(level Level, extraStackDepth int, handlers []Handler) log.Handler {
 	var logHandler log.Handler
 
@@ -196,7 +207,12 @@ func newLoggerHandler(level Level, extraStackDepth int, handlers []Handler) log.
 			}
 			handlerArr = append(handlerArr, lh)
 		}
-		logHandler = log.MultiHandler(handlerArr...)
+
+		if len(handlerArr) == 1 {
+			logHandler = handlerArr[0]
+		} else {
+			logHandler = log.MultiHandler(handlerArr...)
+		}
 	}
 
 	return log.LvlFilterHandler(log.Lvl(level),

--- a/log/log.go
+++ b/log/log.go
@@ -1,3 +1,5 @@
+// Package log defines a complete logging API,
+// and is to be used for all 0-Disk info/error logging purposes.
 package log
 
 import (

--- a/nbdserver/ardb/inmemory.go
+++ b/nbdserver/ardb/inmemory.go
@@ -19,6 +19,9 @@ func newInMemoryStorage(vdiskID string, blockSize int64) backendStorage {
 // inMemoryStorage is a backendStorage implementation,
 // that simply stores each block in-memory,
 // only meant for dev and test purposes.
+// Altought we might want to turn this into a proper supported storage,
+// see the following open issue for more info:
+// https://github.com/zero-os/0-Disk/issues/222
 type inMemoryStorage struct {
 	blockSize int64
 	vdiskID   string

--- a/nbdserver/ardb/storage.go
+++ b/nbdserver/ardb/storage.go
@@ -7,7 +7,7 @@ import (
 )
 
 // backendStorage defines the interface for the actual storage implementation,
-// used by ArbdBackend for a particular vdisk
+// used by the ArbdBackend for a particular vdisk
 type backendStorage interface {
 	Set(blockIndex int64, content []byte) (err error)
 	Merge(blockIndex, offset int64, content []byte) (err error)
@@ -24,8 +24,8 @@ type backendStorage interface {
 func redisBytes(reply interface{}, replyErr error) (content []byte, err error) {
 	content, err = redis.Bytes(reply, replyErr)
 	// This could happen in case the block doesn't exist,
-	// or in case the block is a nullblock.
-	// in both cases we want to simply return it as a null block.
+	// or in case the block is a nil block.
+	// in both cases we want to simply return it as a nil block.
 	if err == redis.ErrNil {
 		err = nil
 	}

--- a/nbdserver/ardb/tlog_gap_test.go
+++ b/nbdserver/ardb/tlog_gap_test.go
@@ -82,7 +82,8 @@ func TestTlogStorageSlow(t *testing.T) {
 
 // slowInMemoryStorage is a wrapper of the inMemoryStorage
 // which simply slows done the speed of its operations
-// by sleeping before actually running a modification command
+// by sleeping before actually running a modification command.
+// Used only in TestTlogStorageSlow.
 type slowInMemoryStorage struct {
 	storage      *inMemoryStorage
 	modSleepTime time.Duration

--- a/nbdserver/exportcontroller.go
+++ b/nbdserver/exportcontroller.go
@@ -24,7 +24,7 @@ func NewExportController(cfg config.HotReloader, tlsOnly bool) (controller *Expo
 }
 
 // ExportController implements nbd.ExportConfigManager
-// using the GridAPI stateless client internally
+// using the NBDServer HotReloader internally.
 type ExportController struct {
 	cfg     config.HotReloader
 	tlsOnly bool

--- a/nbdserver/lba/shard.go
+++ b/nbdserver/lba/shard.go
@@ -9,13 +9,15 @@ import (
 )
 
 const (
-	//NumberOfRecordsPerLBAShard is the fixed length of the LBAShards
+	// NumberOfRecordsPerLBAShard is the fixed length of the LBAShards
 	NumberOfRecordsPerLBAShard = 128
 	// BytesPerShard defines how many bytes each shards requires
 	BytesPerShard = NumberOfRecordsPerLBAShard * zerodisk.HashSize
 )
 
 var (
+	// internal error which is returned
+	// in case a pure nil shard is being written
 	errNilShardWrite = errors.New("shard is nil, and cannot be written")
 )
 

--- a/redisstub/redis.go
+++ b/redisstub/redis.go
@@ -4,22 +4,24 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/zero-os/0-Disk/log"
 	"github.com/garyburd/redigo/redis"
 	"github.com/siddontang/ledisdb/config"
 	"github.com/siddontang/ledisdb/server"
+	"github.com/zero-os/0-Disk/log"
 )
 
 // NewMemoryRedis creates a new in-memory redis stub.
 // It must be noted that the stub only partially redis-compliant,
 // not all commands (such as MULTI/EXEC) are supported.
+// All available commands can be found at:
+// https://github.com/siddontang/ledisdb/blob/master/doc/commands.md
 // WARNING: should be used for testing/dev purposes only!
 func NewMemoryRedis() *MemoryRedis {
 	cfg := config.NewConfigDefault()
 	cfg.DBName = "memory"
 	cfg.DataDir, _ = ioutil.TempDir("", "redisstub")
 	// assigning the empty string to Addr,
-	// such that it chooses a local port by itself
+	// such that it auto-assigns a free local port
 	cfg.Addr = ""
 
 	app, err := server.NewApp(cfg)
@@ -54,7 +56,8 @@ func (mr *MemoryRedis) Dial(connectionString string, database int) (redis.Conn, 
 	return redis.Dial("tcp", mr.addr, redis.DialDatabase(database))
 }
 
-// Close the embedded Go Redis Server.
+// Close the embedded Go Redis Server,
+// and delete the used datadir.
 func (mr *MemoryRedis) Close() {
 	os.Remove(mr.datadir)
 	mr.app.Close()

--- a/scripts/codegeneration.sh
+++ b/scripts/codegeneration.sh
@@ -12,6 +12,8 @@ generate_and_check() {
         exit 0
     fi
 
+    # turns out that that there are uncomitted changes possible
+    # in the generated code, exit with an error
     echo -e "changes detected, run 'go generate \"$DIR\"' and commit generated code in these files:\n"
     echo "$GITSTATUS"
     exit 1

--- a/scripts/updatedependencies.py
+++ b/scripts/updatedependencies.py
@@ -5,6 +5,7 @@ import json
 
 from subprocess import call
 
+# define the absolute location of the Godeps dependency file
 GO_SRC_DIR = os.path.join(os.environ["GOPATH"], "src")
 ROOT_DIR = os.path.join(GO_SRC_DIR, "github.com", "zero-os", "0-Disk")
 DEPS_FILE = os.path.join(ROOT_DIR, "Godeps", "Godeps.json")

--- a/tlog/readme.md
+++ b/tlog/readme.md
@@ -34,41 +34,6 @@ See the [README](tlogclient/readme.md) there for more details.
 
 ## TLOG Server
 
-- TLOG Server store received log entries and store it in memmory
-- After storing log entry it replies to the client on successfull transaction.
-- after timeout or size of the aggregation is reached, we `Flush` it:
-	- aggregate the entries
-	- compress the aggregate
-	- encrypt the compressed aggregate
-	- erasure encode the encrypted aggregate
-	- store each pieces of erasure encoded pieces to ardb in parallel way
-
-- Ideal setup would be to spread erasure coded pieces on different ardb instances.
-- Each instance is used to keep erasure coded part according to its index (erasure coded part index == ardb instance index)
-- We keep only backward links in our blockchain of history. We will add separate forward lining structure later in case it will be needed for the speed of recovery
-
-
-### Flush Settings
-
-settings directly related to flush:
-- flush-size: minimum number of blocks to be flushed
-- flush-time: maximum time we can wait entries before flushing it.
-- k : number of erasure encoded data pieces
-- m : number of erasure encoded coding/parity pieces
-- nonce: hex nonce used for encryption 
-- priv-key: encryption private key
-
-### Tlog Aggregation structure:
-Tlog aggregation per vdisk
-```
-name (Text)          # unused now
-size (uint64)        # number of blocks in this aggregation
-timestamp (uint64)
-vdiskID (uint32)     # vdisk ID
-Blocks: List(Block)  
-prev: Data           # hash of previous aggregation
-```
-
 The server code is in the [`tlogserver`](tlogserver/) directory, see the [README](tlogserver/README.md) there for more details.
 
 ## Code Generation

--- a/tlog/tlogclient/decoder/decoder.go
+++ b/tlog/tlogclient/decoder/decoder.go
@@ -62,6 +62,7 @@ func New(pool tlog.RedisPool, k, m int, vdiskID, privKey, hexNonce string) (*Dec
 	}, nil
 }
 
+// Close releases all of it's acquired resources.
 func (d *Decoder) Close() {
 	d.pool.Close()
 }

--- a/tlog/tlogclient/decoder/limiter.go
+++ b/tlog/tlogclient/decoder/limiter.go
@@ -8,15 +8,19 @@ import (
 // in order for the decoder to know which aggregations
 // it needs to decode
 type Limiter interface {
-	// EndAgg returns true if it is the end  of the
-	// aggregation we want to decode
-	EndAgg(*schema.TlogAggregation, schema.TlogBlock_List) bool
 
 	// StartAgg returns true if it is the start of the
 	// aggregation we want to decode
 	StartAgg(*schema.TlogAggregation, schema.TlogBlock_List) bool
 
+	// EndAgg returns true if it is the end  of the
+	// aggregation we want to decode
+	EndAgg(*schema.TlogAggregation, schema.TlogBlock_List) bool
+
+	// StartBlock returns true if it is the start of block we want to decode
 	StartBlock(schema.TlogBlock) bool
+
+	// EndBlock returns true if it is the end of block we want to decode
 	EndBlock(schema.TlogBlock) bool
 }
 
@@ -69,11 +73,14 @@ func (lbt LimitByTimestamp) StartBlock(block schema.TlogBlock) bool {
 	return block.Timestamp() >= lbt.startTs
 }
 
+// LimitBySequence implement Limiter interface which is limited by
+// start and end sequence
 type LimitBySequence struct {
 	startSeq uint64
 	endSeq   uint64
 }
 
+// NewLimitBySequence creates new LimitBySequence object
 func NewLimitBySequence(startSeq, endSeq uint64) LimitBySequence {
 	return LimitBySequence{
 		startSeq: startSeq,

--- a/tlog/tlogclient/player/player.go
+++ b/tlog/tlogclient/player/player.go
@@ -46,16 +46,13 @@ func NewPlayer(ctx context.Context, configPath string, serverConfigs []zerodiskc
 		return nil, err
 	}
 
-	// create ardb backend
-	redisPool := ardb.NewRedisPool(nil)
-
 	hotreloader, err := zerodiskcfg.NopHotReloader(configPath, zerodiskcfg.NBDServer)
 	if err != nil {
 		return nil, err
 	}
 
 	config := ardb.BackendFactoryConfig{
-		Pool:              redisPool,
+		PoolFactory:       ardb.NewRedisPoolFactory(nil),
 		ConfigHotReloader: hotreloader,
 		LBACacheLimit:     ardb.DefaultLBACacheLimit,
 	}

--- a/tlog/tlogclient/player/player.go
+++ b/tlog/tlogclient/player/player.go
@@ -23,9 +23,12 @@ type Player struct {
 	ctx     context.Context
 }
 
+// OnReplayCb defines func signature which can be used as callback
+// for the Replay* functions.
+// This callback is going to be executed on each block replay.
 type OnReplayCb func(seq uint64) error
 
-func OnReplayCbNone(seq uint64) error {
+func onReplayCbNone(seq uint64) error {
 	return nil
 }
 
@@ -96,17 +99,22 @@ func NewPlayerWithPoolAndBackend(ctx context.Context, pool tlog.RedisPool, backe
 
 }
 
+// Close releases all its resources
 func (p *Player) Close() {
 	p.dec.Close()
 	p.backend.Close(p.ctx)
 }
 
-// Replay replays the tlog by decoding data from a tlog RedisPool.
-// The replay start from `startTs` timestamp.
+// Replay replays the tlog by decoding data from the tlog blockchains.
+// lmt implements the decoder.Limiter interface which specify start and end of the
+// data we want to replay. It returns last sequence number it replayed.
 func (p *Player) Replay(lmt decoder.Limiter) (uint64, error) {
-	return p.ReplayWithCallback(lmt, OnReplayCbNone)
+	return p.ReplayWithCallback(lmt, onReplayCbNone)
 }
 
+// ReplayWithCallback replays
+// lmt implements the decoder.Limiter interface which specify start and end of the
+// It returns last sequence number it replayed.
 func (p *Player) ReplayWithCallback(lmt decoder.Limiter, onReplayCb OnReplayCb) (uint64, error) {
 	var lastSeq uint64
 	var err error
@@ -129,11 +137,15 @@ func (p *Player) ReplayWithCallback(lmt decoder.Limiter, onReplayCb OnReplayCb) 
 	return lastSeq, p.backend.Flush(p.ctx)
 }
 
+// ReplayAggregation replays an aggregation.
+// It returns last sequence number it replayed.
 func (p *Player) ReplayAggregation(agg *schema.TlogAggregation, lmt decoder.Limiter) (uint64, error) {
-	return p.ReplayAggregationWithCallback(agg, lmt, OnReplayCbNone)
+	return p.ReplayAggregationWithCallback(agg, lmt, onReplayCbNone)
 }
 
-// ReplayAggregation replays an aggregation
+// ReplayAggregationWithCallback replays an aggregation with a callback.
+// The callback is executed after it replay a block.
+// It returns last sequence number it replayed.
 func (p *Player) ReplayAggregationWithCallback(agg *schema.TlogAggregation, lmt decoder.Limiter,
 	onReplayCb OnReplayCb) (uint64, error) {
 

--- a/tlog/tlogserver/aggmq/comm.go
+++ b/tlog/tlogserver/aggmq/comm.go
@@ -7,8 +7,15 @@ import (
 
 const (
 	_ = iota
+
+	// CmdWaitSlaveSync is command given to slave syncer.
+	// It indicates to the syncer that we want to wait for slave syncer to finish it's work
 	CmdWaitSlaveSync
+
+	// CmdRestartSlaveSyncer is command to restart the slave syncer
 	CmdRestartSlaveSyncer
+
+	// CmdKillMe is command to kill the slave syncer
 	CmdKillMe
 )
 

--- a/tlog/tlogserver/slavesync/slave_sync.go
+++ b/tlog/tlogserver/slavesync/slave_sync.go
@@ -150,7 +150,7 @@ func (ss *slaveSyncer) Close() {
 
 func (ss *slaveSyncer) restart() {
 	if err := ss.init(); err != nil {
-		log.Errorf("restarting slave syncer for `%v` failed: %v", err)
+		log.Errorf("restarting slave syncer for `%v` failed: %v", ss.vdiskID, err)
 		return
 	}
 }

--- a/tlog/tlogserver/slavesync_test.go
+++ b/tlog/tlogserver/slavesync_test.go
@@ -452,10 +452,6 @@ func newTestNbdBackend(ctx context.Context, t *testing.T, vdiskID, tlogrpc strin
 
 func newTestNbdBackendWithConfigPath(ctx context.Context, t *testing.T, vdiskID, tlogrpc string,
 	blockSize, size uint64, configPath string) (nbd.Backend, error) {
-
-	// redis pool
-	redisPool := ardb.NewRedisPool(nil)
-
 	hotreloader, err := config.NewHotReloader(configPath, config.NBDServer)
 	if err != nil {
 		return nil, err
@@ -463,7 +459,7 @@ func newTestNbdBackendWithConfigPath(ctx context.Context, t *testing.T, vdiskID,
 	go hotreloader.Listen(ctx)
 
 	config := ardb.BackendFactoryConfig{
-		Pool:              redisPool,
+		PoolFactory:       ardb.NewRedisPoolFactory(nil),
 		ConfigHotReloader: hotreloader,
 		LBACacheLimit:     1024 * 1024,
 		TLogRPCAddress:    tlogrpc,

--- a/version.go
+++ b/version.go
@@ -35,8 +35,8 @@ func (v Version) Compare(other Version) int {
 
 	// actual versions are equal, so let's see if one
 	// of them is in the non-production stage,
-	// in which case the 1 in production is greater
-	// then the one in prerelease or lower
+	// in which case the one in production is greater
+	// than the one in prerelease
 
 	preA := VersionStage(v)
 	preB := VersionStage(other)
@@ -84,7 +84,8 @@ func (v Version) String() string {
 	return str
 }
 
-// VersionStage defines the stage of the version
+// VersionStage defines the stage of the version.
+// This type can also be used to cast a Version to a VersionStage.
 type VersionStage uint8
 
 // The different version stages

--- a/zeroctl/cmd/copyvdisk/nondeduped.go
+++ b/zeroctl/cmd/copyvdisk/nondeduped.go
@@ -12,12 +12,6 @@ func copyNondedupedSameConnection(sourceID, targetID string, conn redis.Conn) (e
 	defer conn.Close()
 
 	script := redis.NewScript(0, `
-if #ARGV ~= 2 then
-    local usage = "copyNondedupedSameConnection script usage: source destination"
-    redis.log(redis.LOG_NOTICE, usage)
-    error("copyNondedupedSameConnection script requires 2 arguments (source destination)")
-end
-
 local source = ARGV[1]
 local destination = ARGV[2]
 
@@ -64,11 +58,6 @@ func copyNondedupedDifferentConnections(sourceID, targetID string, connA, connB 
 	}
 	log.Infof("collected %d block indices from source vdisk %q",
 		len(data), sourceID)
-
-	// ensure the vdisk isn't touched while we're creating it
-	if err = connB.Send("WATCH", targetID); err != nil {
-		return
-	}
 
 	// start the copy transaction
 	if err = connB.Send("MULTI"); err != nil {

--- a/zeroctl/cmd/copyvdisk/vdisk.go
+++ b/zeroctl/cmd/copyvdisk/vdisk.go
@@ -53,7 +53,7 @@ func copyVdisk(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// get source vdisk, and ensure that targetCluster has a value
+	// get source vdisk, and ensure that targetCluster has a valid value
 	sourceVdisk, ok := cfg.Vdisks[sourceVdiskID]
 	if !ok {
 		return fmt.Errorf("vdisk %s could not be found in config %s",
@@ -85,7 +85,7 @@ func copyVdisk(cmd *cobra.Command, args []string) error {
 	}
 }
 
-// NOTE: copies metadata onlY!
+// NOTE: copies metadata only!
 func copyDedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster config.StorageClusterConfig) error {
 	if sourceCluster.MetadataStorage == nil {
 		return errors.New("no metaDataServer given for source")
@@ -127,10 +127,12 @@ func copyNondedupedVdisk(sourceID, targetID string, sourceCluster, targetCluster
 	// WARNING: [TODO]
 	// Currently the result will be WRONG in case targetDataServerCount != sourceDataServerCount,
 	// as the storage data spread will not be the same,
-	// to what the nbdserver read calls will expect
+	// to what the nbdserver read calls will expect.
+	// See open issue for more information:
+	// https://github.com/zero-os/0-Disk/issues/206
 	for i := 0; i < sourceDataServerCount; i++ {
 		sourceCfg = sourceCluster.DataStorage[i]
-		targetCfg = targetCluster.DataStorage[i%targetDataServerCount]
+		targetCfg = targetCluster.DataStorage[i]
 
 		// within same storage server
 		if sourceCfg == targetCfg {

--- a/zeroctl/cmd/delvdisk/deduped.go
+++ b/zeroctl/cmd/delvdisk/deduped.go
@@ -11,7 +11,7 @@ import (
 // delete the metadata of deduped vdisks
 func deleleDedupedVdisksMetadata(force bool, cfg config.StorageServerConfig, vdiskids ...string) error {
 	if len(vdiskids) == 0 {
-		return nil
+		return nil // no vdisks to delete, returning early
 	}
 
 	// open redis connection
@@ -22,7 +22,7 @@ func deleleDedupedVdisksMetadata(force bool, cfg config.StorageServerConfig, vdi
 	}
 	defer conn.Close()
 
-	// cache delete request of each vdisk
+	// add each delete request to the pipeline
 	var delVdisks []string
 	for _, vdiskID := range vdiskids {
 		log.Infof("deleting metadata of vdisk %s...", vdiskID)

--- a/zeroctl/cmd/delvdisk/nondeduped.go
+++ b/zeroctl/cmd/delvdisk/nondeduped.go
@@ -11,7 +11,7 @@ import (
 // delete the data of nondeduped vdisks
 func deleleNondedupedVdisks(force bool, cfg config.StorageServerConfig, vdiskids ...string) error {
 	if len(vdiskids) == 0 {
-		return nil
+		return nil // no vdisks to delete, early return
 	}
 
 	// open redis connection
@@ -22,7 +22,7 @@ func deleleNondedupedVdisks(force bool, cfg config.StorageServerConfig, vdiskids
 	}
 	defer conn.Close()
 
-	// cache delete request of each vdisk
+	// add each delete request to the pipeline
 	var delVdisks []string
 	for _, vdiskID := range vdiskids {
 		log.Infof("deleting data of nondeduped vdisk %s...", vdiskID)
@@ -31,9 +31,10 @@ func deleleNondedupedVdisks(force bool, cfg config.StorageServerConfig, vdiskids
 			if !force {
 				return err
 			}
-			log.Error("could not delete nondeduped vdisk: ", vdiskID)
+			log.Error("could not add delete request for vdisk: ", vdiskID)
 			continue
 		}
+
 		delVdisks = append(delVdisks, vdiskID)
 	}
 

--- a/zeroctl/cmd/list/vdisk.go
+++ b/zeroctl/cmd/list/vdisk.go
@@ -84,6 +84,7 @@ func listVdisks(cmd *cobra.Command, args []string) error {
 	var ok bool
 	var vdiskID string
 
+	// only log each vdisk once
 	uniqueVdisks := make(map[string]struct{})
 	for _, vdisk := range vdisks {
 		vdiskID = string(vdisk)

--- a/zeroctl/cmd/restore/vdisk_test.go
+++ b/zeroctl/cmd/restore/vdisk_test.go
@@ -3,6 +3,7 @@ package restore
 import (
 	"context"
 	crand "crypto/rand"
+	"fmt"
 	"io/ioutil"
 	mrand "math/rand"
 	"os"
@@ -12,6 +13,7 @@ import (
 	zerodiskcfg "github.com/zero-os/0-Disk/config"
 	"github.com/zero-os/0-Disk/gonbdserver/nbd"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbdserver/ardb"
 	"github.com/zero-os/0-Disk/tlog/tlogclient/decoder"
 	"github.com/zero-os/0-Disk/tlog/tlogclient/player"
 	"github.com/zero-os/0-Disk/tlog/tlogserver/server"
@@ -221,6 +223,35 @@ func testEndToEndReplay(t *testing.T, vdiskType zerodiskcfg.VdiskType) {
 			return
 		}
 	}
+}
+
+// create a new backend, used for writing
+func newBackend(ctx context.Context, dial ardb.DialFunc, tlogrpc, vdiskID, configPath string) (nbd.Backend, error) {
+	hotreloader, err := zerodiskcfg.NopHotReloader(configPath, zerodiskcfg.NBDServer)
+	if err != nil {
+		return nil, err
+	}
+
+	config := ardb.BackendFactoryConfig{
+		PoolFactory:       ardb.NewRedisPoolFactory(dial),
+		ConfigHotReloader: hotreloader,
+		LBACacheLimit:     ardb.DefaultLBACacheLimit,
+		TLogRPCAddress:    tlogrpc,
+	}
+	fact, err := ardb.NewBackendFactory(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create factory:%v", err)
+	}
+
+	ec := &nbd.ExportConfig{
+		Name:        vdiskID,
+		Description: "zero-os/zerodisk",
+		Driver:      "ardb",
+		ReadOnly:    false,
+		TLSOnly:     false,
+	}
+
+	return fact.NewBackend(ctx, ec)
 }
 
 // create a test backend

--- a/zeroctl/cmd/version.go
+++ b/zeroctl/cmd/version.go
@@ -23,6 +23,8 @@ var VersionCmd = &cobra.Command{
 	Run:   outputVersion,
 }
 
+// outputVersion prints to the STDOUT,
+// the tool version, runtime info, and optionally the commit hash.
 func outputVersion(*cobra.Command, []string) {
 	// Tool Version
 	version := "Version: " + zerodisk.CurrentVersion.String()

--- a/zeroctl/main.go
+++ b/zeroctl/main.go
@@ -3,5 +3,7 @@ package main
 import "github.com/zero-os/0-Disk/zeroctl/cmd"
 
 func main() {
+	// run the command in question (defined by the cli args)
+	// see cmd dir for the possible commands and their behavior
 	cmd.Execute()
 }


### PR DESCRIPTION
+ Improve in-line code comments of the codebase;
+ Use a `RedisPoolFactory`, such that each vdisk gets its own `RedisPool`, rather than sharing one between all vdisks for the entire `nbdserver` lifetime (not sure why there was never a complaint related to this unreported issue);
+ Some other tiny code improvements here and there;