### PR TITLE
Fix tlog test multipleserver

### DIFF
--- a/tlog/tlogclient/common_test.go
+++ b/tlog/tlogclient/common_test.go
@@ -25,6 +25,7 @@ func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan
 		select {
 		case <-time.After(20 * time.Second):
 			t.Fatal("testClientWaitSeqFlushed timeout")
+			return
 		case re := <-respChan:
 			if re.Err != nil {
 				t.Logf("recv err = %v", re.Err)

--- a/tlog/tlogclient/multiple_server_test.go
+++ b/tlog/tlogclient/multiple_server_test.go
@@ -59,18 +59,24 @@ type testTwoServerConf struct {
 // Start tlog decoder
 // - make sure all sequence successfully decoded
 func TestMultipleServerBasic(t *testing.T) {
+	log.Info("TestMultipleServerBasic")
+
 	conf := testMultipleServerBasicConf()
 	conf.masterStopped = true
 	testTwoServers(t, conf)
 }
 
 func TestMultipleServerBasicMasterFailToFlush(t *testing.T) {
+	log.Info("TestMultipleServerBasicMasterFailToFlush")
+
 	conf := testMultipleServerBasicConf()
 	conf.masterFailedToFlush = true
 	testTwoServers(t, conf)
 }
 
 func TestMultipleServerBasicHotReload(t *testing.T) {
+	log.Info("TestMultipleServerBasicHotReload")
+
 	conf := testMultipleServerBasicConf()
 	conf.hotReload = true
 	testTwoServers(t, conf)
@@ -90,12 +96,16 @@ func testMultipleServerBasicConf() testTwoServerConf {
 // TestMultipleServerResendUnflushed test multiple servers
 // in case the 1st tlog server has some unflushed blocks
 func TestMultipleServerResendUnflushed(t *testing.T) {
+	log.Info("TestMultipleServerResendUnflushed")
+
 	conf := testMultipleServerResendUnflushedConf()
 	conf.masterStopped = true
 	testTwoServers(t, conf)
 }
 
 func TestMultipleServerResendUnflushedMasterFailFlush(t *testing.T) {
+	log.Info("TestMultipleServerResendUnflushedMasterFailFlush")
+
 	conf := testMultipleServerResendUnflushedConf()
 	conf.masterFailedToFlush = true
 	testTwoServers(t, conf)
@@ -103,6 +113,8 @@ func TestMultipleServerResendUnflushedMasterFailFlush(t *testing.T) {
 }
 
 func TestMultipleServerResendHotReload(t *testing.T) {
+	log.Info("TestMultipleServerResendHotReload")
+
 	conf := testMultipleServerResendUnflushedConf()
 	conf.hotReload = true
 	testTwoServers(t, conf)

--- a/tlog/tlogclient/multiple_server_test.go
+++ b/tlog/tlogclient/multiple_server_test.go
@@ -174,7 +174,7 @@ func testTwoServers(t *testing.T, ttConf testTwoServerConf) {
 
 	respChan := client.Recv()
 
-	t.Log("write data to server #1")
+	log.Info("write data to server #1")
 
 	seqs := make(map[uint64]struct{})
 	for i := ttConf.firstSendStartSeq; i <= ttConf.firstSendEndSeq; i++ {
@@ -188,6 +188,7 @@ func testTwoServers(t *testing.T, ttConf testTwoServerConf) {
 	// wait for it to be flushed
 	testClientWaitSeqFlushed(ctx1, t, respChan, cancelFunc1, ttConf.firstWaitEndSeq)
 
+	log.Info("simulate failover scenario")
 	switch {
 	case ttConf.masterStopped:
 		// simulate stopping server 1
@@ -203,7 +204,7 @@ func testTwoServers(t *testing.T, ttConf testTwoServerConf) {
 		client.ChangeServerAddrs([]string{t2.ListenAddr()})
 	}
 
-	t.Log("write data to server #2")
+	log.Info("write data again, should be handled by server #2")
 	for i := ttConf.secondSendStartSeq; i <= ttConf.secondSendEndSeq; i++ {
 		seqs[i] = struct{}{}
 	}

--- a/tlog/tlogserver/server/vdisk_mgr.go
+++ b/tlog/tlogserver/server/vdisk_mgr.go
@@ -55,7 +55,8 @@ func (vt *vdiskManager) Get(ctx context.Context, vdiskID string, firstSequence u
 	}
 
 	// create vdisk
-	vd, err = newVdisk(ctx, vt.aggMq, vdiskID, vt.configPath, f, firstSequence, flusherConf, vt.maxSegmentBufLen)
+	vd, err = newVdisk(ctx, vt.aggMq, vdiskID, vt.configPath, f, firstSequence, flusherConf, vt.maxSegmentBufLen,
+		vt.remove)
 	if err != nil {
 		return
 	}
@@ -65,4 +66,10 @@ func (vt *vdiskManager) Get(ctx context.Context, vdiskID string, firstSequence u
 	log.Debugf("create vdisk with expectedSequence:%v", vd.expectedSequence)
 
 	return
+}
+
+func (vt *vdiskManager) remove(vdiskID string) {
+	vt.lock.Lock()
+	defer vt.lock.Unlock()
+	delete(vt.vdisks, vdiskID)
 }


### PR DESCRIPTION
#310 fix attempt

- tlogclient always move to other server in any case of failures
- tlogserver's vdisk exit on failed flush
- better test logging by using the logger package inside the test. It is because test logger always printed after our logger package, which make the debugging to be hard.

It passed 9 travis builds :)