### PR TITLE
Fix usage of parent context.

### DIFF
--- a/tlog/tlogclient/common_test.go
+++ b/tlog/tlogclient/common_test.go
@@ -25,7 +25,6 @@ func testClientWaitSeqFlushed(ctx context.Context, t *testing.T, respChan <-chan
 		select {
 		case <-time.After(20 * time.Second):
 			t.Fatal("testClientWaitSeqFlushed timeout")
-			return
 		case re := <-respChan:
 			if re.Err != nil {
 				t.Logf("recv err = %v", re.Err)


### PR DESCRIPTION
improvement regarding #320 code review

- Use parent context when creating new context
- No need to `Done()` on parent context.