### PR TITLE
tlogclient : fix first sequence used to reconnect.

### DIFF
--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -170,7 +170,7 @@ func (c *Client) reconnect(closedTime time.Time) error {
 		// try other server
 		c.shiftServerAddr()
 
-		if err = c.connect(c.blockBuffer.MinSequence(), false); err == nil {
+		if err = c.connect(c.blockBuffer.LastFlushed()+1, false); err == nil {
 			c.lastConnected = time.Now()
 
 			// if reconnect success, sent all unflushed blocks


### PR DESCRIPTION
Fixes #310

Client.blockbuffer now save the last flushed sequence.
It simplify the code and make it more reliable.

