### PR TITLE
tlogclient : fix race condition when waiting for sync.Cond variable.

### DIFF
--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -443,14 +443,18 @@ func (c *Client) WaitNbdSlaveSync() error {
 // wait for a condition to happens
 // it happens when the channel is closed
 func (c *Client) waitCond(cond *sync.Cond) chan struct{} {
-	// create goroutine to listen to it's completeness
-	doneCh := make(chan struct{})
+	doneCh := make(chan struct{})        // channel to wait for waiter completion
+	waiterStarted := make(chan struct{}) // channel to wait for waiter start
+
 	go func() {
 		cond.L.Lock()
+		waiterStarted <- struct{}{}
 		cond.Wait()
 		cond.L.Unlock()
 		close(doneCh)
 	}()
+
+	<-waiterStarted
 	return doneCh
 }
 


### PR DESCRIPTION
Fixes #331 
Make sure the waiter goroutine started before we start the work we wait.

More description can be found at https://github.com/zero-os/0-Disk/issues/331#issuecomment-316595240