### PR TITLE
remote backendStorage.Merge interface method

### DIFF
--- a/nbdserver/ardb/ardb_test.go
+++ b/nbdserver/ardb/ardb_test.go
@@ -78,7 +78,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 
 	var (
 		testContentA = []byte{4, 2}
-		testContentB = []byte{9, 2}
 	)
 	const (
 		testBlockIndexA = 0
@@ -133,34 +132,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 		t.Fatalf("found content %v, while expected nil-content", content)
 	}
 
-	// Merging new content with non existing content is fine
-	err = storage.Merge(testBlockIndexB, 0, testContentB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// getting the content should be fine
-	content, err = storage.Get(testBlockIndexB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(content) < 2 || bytes.Compare(testContentB, content[:2]) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-
-	// Merging existing content is fine as well
-	err = storage.Merge(testBlockIndexB, 1, testContentA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// getting the content should be fine
-	content, err = storage.Get(testBlockIndexB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare([]byte{9, 4, 2, 0, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-
 	// Deleting content, should really delete it
 	err = storage.Delete(testBlockIndexA)
 	if err != nil {
@@ -174,19 +145,6 @@ func testBackendStorage(t *testing.T, storage backendStorage) {
 	}
 	if content != nil {
 		t.Fatalf("found content %v, while expected nil-content", content)
-	}
-	err = storage.Merge(testBlockIndexA, 0, testContentA)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// content should be merged
-	content, err = storage.Get(testBlockIndexA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare([]byte{4, 2, 0, 0, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
 	}
 
 	// Deleting content, should really delete it
@@ -216,7 +174,6 @@ func testBackendStorageForceFlush(t *testing.T, storage backendStorage) {
 
 	var (
 		testContentA = []byte{4, 2}
-		testContentB = []byte{9, 2}
 	)
 	const (
 		testBlockIndexA = 0
@@ -294,58 +251,6 @@ func testBackendStorageForceFlush(t *testing.T, storage backendStorage) {
 		t.Fatalf("found content %v, while expected nil-content", content)
 	}
 
-	// Merging new content with non existing content is fine
-	err = storage.Merge(testBlockIndexB, 0, testContentB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// getting the content should be fine
-	content, err = storage.Get(testBlockIndexB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(content) < 2 || bytes.Compare(testContentB, content[:2]) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-	err = storage.Flush()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// getting the content should still be fine
-	content, err = storage.Get(testBlockIndexB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(content) < 2 || bytes.Compare(testContentB, content[:2]) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-
-	// Merging existing content is fine as well
-	err = storage.Merge(testBlockIndexB, 1, testContentA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// getting the content should be fine
-	content, err = storage.Get(testBlockIndexB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare([]byte{9, 4, 2, 0, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-	err = storage.Flush()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// getting the content should still be fine
-	content, err = storage.Get(testBlockIndexB)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare([]byte{9, 4, 2, 0, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-
 	// Deleting content, should really delete it
 	err = storage.Delete(testBlockIndexA)
 	if err != nil {
@@ -363,33 +268,6 @@ func testBackendStorageForceFlush(t *testing.T, storage backendStorage) {
 	}
 	if content != nil {
 		t.Fatalf("found content %v, while expected nil-content", content)
-	}
-	err = storage.Merge(testBlockIndexA, 0, testContentA)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// content should be merged
-	content, err = storage.Get(testBlockIndexA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare([]byte{4, 2, 0, 0, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-
-	err = storage.Flush()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// content should still be merged
-	content, err = storage.Get(testBlockIndexA)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if bytes.Compare([]byte{4, 2, 0, 0, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
 	}
 
 	// Deleting content, should really delete it
@@ -475,39 +353,6 @@ func testBackendStorageDeadlock(t *testing.T, blockSize, blockCount int64, stora
 	}
 
 	var wg sync.WaitGroup
-
-	// merge all content four times (async)
-	for time := int64(0); time < 4; time++ {
-		for i := int64(0); i < blockCount; i += 2 {
-			blockIndex := i
-			wg.Add(1)
-			go func(curTime int64) {
-				defer wg.Done()
-
-				// get preContent
-				preContent, err := storage.Get(blockIndex)
-				if err != nil {
-					t.Fatal(curTime, blockIndex, err)
-					return
-				}
-
-				// merge it
-				offset := 2 + curTime
-				blockIndex = (blockIndex + 1) % blockCount
-				err = storage.Merge(blockIndex, offset, preContent)
-				if err != nil {
-					t.Fatal(curTime, blockIndex, err)
-				}
-			}(time)
-		}
-	}
-
-	wg.Wait()
-
-	// let's flush the merged content
-	if err := storage.Flush(); err != nil {
-		t.Fatal(err)
-	}
 
 	// delete all content (async)
 	for i := int64(0); i < blockCount; i++ {

--- a/nbdserver/ardb/backend_test.go
+++ b/nbdserver/ardb/backend_test.go
@@ -1,0 +1,140 @@
+package ardb
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func testBackendReadWrite(ctx context.Context, t *testing.T, vdiskID string, blockSize int64, size uint64, storage backendStorage) {
+	if !assert.NotNil(t, storage) {
+		return
+	}
+
+	vComp := new(vdiskCompletion)
+	backend := newBackend(vdiskID, blockSize, size, storage, nil, vComp)
+	if !assert.NotNil(t, backend) {
+		return
+	}
+	go backend.GoBackground(ctx)
+	defer backend.Close(ctx)
+
+	someContent := make([]byte, blockSize)
+	for i := range someContent {
+		someContent[i] = byte(i % 255)
+	}
+
+	nilContent := make([]byte, blockSize)
+
+	// ensure the content doest not exist yet
+	payload, err := backend.ReadAt(ctx, 0, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, nilContent, payload) {
+		return
+	}
+	payload, err = backend.ReadAt(ctx, blockSize, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, nilContent, payload) {
+		return
+	}
+
+	// write first block
+	bw, err := backend.WriteAt(ctx, someContent, 0)
+	if !assert.NoError(t, err) || !assert.Equal(t, blockSize, bw) {
+		return
+	}
+	// first block should now exist
+	payload, err = backend.ReadAt(ctx, 0, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, someContent, payload) {
+		return
+	}
+	// second block should still not exist
+	payload, err = backend.ReadAt(ctx, blockSize, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, nilContent, payload) {
+		return
+	}
+
+	// write second block
+	bw, err = backend.WriteAt(ctx, someContent, blockSize)
+	if !assert.NoError(t, err) || !assert.Equal(t, blockSize, bw) {
+		return
+	}
+
+	// both blocks should now exist
+	payload, err = backend.ReadAt(ctx, 0, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, someContent, payload) {
+		return
+	}
+	payload, err = backend.ReadAt(ctx, blockSize, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, someContent, payload) {
+		return
+	}
+
+	midBlockOffset := blockSize / 2
+	midBlockLength := blockSize - midBlockOffset
+
+	// Let's now erase half of the first block by writing zeroes
+	bytesWritten, err := backend.WriteZeroesAt(ctx, midBlockOffset, midBlockLength)
+	if !assert.NoError(t, err) || !assert.Equal(t, midBlockLength, bytesWritten) {
+		return
+	}
+
+	// getting the first block should now result in half of them being zeroes
+	halfNilBlock := make([]byte, blockSize)
+	copy(halfNilBlock[:midBlockOffset], someContent)
+	payload, err = backend.ReadAt(ctx, 0, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, halfNilBlock, payload) {
+		return
+	}
+
+	// let's now delete the content by writing just zeroes
+	bytesWritten, err = backend.WriteZeroesAt(ctx, 0, blockSize)
+	if !assert.NoError(t, err) || !assert.Equal(t, blockSize, bytesWritten) {
+		return
+	}
+	// first block should now be deleted
+	payload, err = backend.ReadAt(ctx, 0, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, nilContent, payload) {
+		return
+	}
+
+	// let's now try to merge a full block (the 2nd one) with some other content
+	bytesWritten, err = backend.WriteAt(ctx, someContent[:midBlockLength], blockSize+midBlockOffset)
+	if !assert.NoError(t, err) || !assert.Equal(t, midBlockLength, bytesWritten) {
+		return
+	}
+	// getting the content should now the first one
+	mergedBlock := make([]byte, blockSize)
+	copy(mergedBlock[:midBlockOffset], someContent)
+	copy(mergedBlock[midBlockOffset:], someContent)
+	payload, err = backend.ReadAt(ctx, blockSize, blockSize)
+	if !assert.NoError(t, err) {
+		return
+	}
+	if !assert.Equal(t, mergedBlock, payload) {
+		return
+	}
+}

--- a/nbdserver/ardb/deduped.go
+++ b/nbdserver/ardb/deduped.go
@@ -2,7 +2,6 @@ package ardb
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/garyburd/redigo/redis"
 
@@ -70,35 +69,6 @@ func (ds *dedupedStorage) Set(blockIndex int64, content []byte) (err error) {
 	}
 
 	return ds.lba.Set(blockIndex, hash)
-}
-
-// Merge implements backendStorage.Merge
-func (ds *dedupedStorage) Merge(blockIndex, offset int64, content []byte) (err error) {
-	hash, _ := ds.lba.Get(blockIndex)
-
-	var mergedContent []byte
-	if hash != nil && !hash.Equals(zerodisk.NilHash) {
-		mergedContent, err = ds.getContent(hash)
-		if err != nil {
-			err = fmt.Errorf("LBA hash refered to non-existing content: %s", err)
-			return
-		}
-		if int64(len(mergedContent)) < ds.blockSize {
-			mc := make([]byte, ds.blockSize)
-			copy(mc, mergedContent)
-			mergedContent = mc
-		}
-	} else {
-		mergedContent = make([]byte, ds.blockSize)
-	}
-
-	// copy in new content
-	copy(mergedContent[offset:], content)
-
-	// store new content
-	// (dereferencing of previousHash happens in ds.Set logic)
-	err = ds.Set(blockIndex, mergedContent)
-	return
 }
 
 // Get implements backendStorage.Get

--- a/nbdserver/ardb/inmemory.go
+++ b/nbdserver/ardb/inmemory.go
@@ -49,28 +49,6 @@ func (ms *inMemoryStorage) Set(blockIndex int64, content []byte) (err error) {
 	return
 }
 
-// Merge implements backendStorage.Merge
-func (ms *inMemoryStorage) Merge(blockIndex, offset int64, content []byte) (err error) {
-	ms.mux.Lock()
-	defer ms.mux.Unlock()
-
-	mergedContent, _ := ms.vdisk[blockIndex]
-	if ocl := int64(len(mergedContent)); ocl == 0 {
-		mergedContent = make([]byte, ms.blockSize)
-	} else if ocl < ms.blockSize {
-		oc := make([]byte, ms.blockSize)
-		copy(oc, mergedContent)
-		mergedContent = oc
-	}
-
-	// copy in new content
-	copy(mergedContent[offset:], content)
-
-	// store new content, as the merged version is non-zero
-	ms.vdisk[blockIndex] = mergedContent
-	return
-}
-
 // Get implements backendStorage.Get
 func (ms *inMemoryStorage) Get(blockIndex int64) (content []byte, err error) {
 	ms.mux.RLock()

--- a/nbdserver/ardb/inmemory_test.go
+++ b/nbdserver/ardb/inmemory_test.go
@@ -1,6 +1,7 @@
 package ardb
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,4 +48,21 @@ func TestInMemoryStorageDeadlock(t *testing.T) {
 	}
 
 	testBackendStorageDeadlock(t, blockSize, blockCount, storage)
+}
+
+func TestInMemoryBackendReadWrite(t *testing.T) {
+	const (
+		vdiskID   = "a"
+		size      = 64
+		blockSize = 8
+	)
+
+	storage := newInMemoryStorage(vdiskID, blockSize)
+	if !assert.NotNil(t, storage) {
+		return
+	}
+
+	ctx := context.Background()
+
+	testBackendReadWrite(ctx, t, vdiskID, blockSize, size, storage)
 }

--- a/nbdserver/ardb/nondeduped_test.go
+++ b/nbdserver/ardb/nondeduped_test.go
@@ -2,6 +2,7 @@ package ardb
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"runtime/debug"
 	"testing"
@@ -307,6 +308,25 @@ func TestGetNondedupedTemplateContentDeadlock(t *testing.T) {
 			t.Fatal(i, "unexpected content")
 		}
 	}
+}
+
+func TestNonDedupedBackendReadWrite(t *testing.T) {
+	const (
+		vdiskID   = "a"
+		size      = 64
+		blockSize = 8
+	)
+
+	memRedis := redisstub.NewMemoryRedis()
+	go memRedis.Listen()
+	defer memRedis.Close()
+
+	provider := newTestRedisProvider(memRedis, nil) // template = nil
+
+	ctx := context.Background()
+
+	testBackendReadWrite(ctx, t, vdiskID, blockSize, size,
+		createTestNondedupedStorage(t, vdiskID, blockSize, false, provider))
 }
 
 func init() {

--- a/nbdserver/ardb/semideduped.go
+++ b/nbdserver/ardb/semideduped.go
@@ -84,25 +84,6 @@ func (sds *semiDedupedStorage) Set(blockIndex int64, content []byte) error {
 	return nil
 }
 
-// Merge implements backendStorage.Merge
-func (sds *semiDedupedStorage) Merge(blockIndex, offset int64, content []byte) error {
-	mergedContent, _ := sds.Get(blockIndex)
-
-	if ocl := int64(len(mergedContent)); ocl == 0 {
-		mergedContent = make([]byte, sds.blockSize)
-	} else if ocl < sds.blockSize {
-		oc := make([]byte, sds.blockSize)
-		copy(oc, mergedContent)
-		mergedContent = oc
-	}
-
-	// copy in new content
-	copy(mergedContent[offset:], content)
-
-	// store new content
-	return sds.Set(blockIndex, mergedContent)
-}
-
 // Get implements backendStorage.Get
 func (sds *semiDedupedStorage) Get(blockIndex int64) ([]byte, error) {
 	// if a bit is enabled in the bitmap,

--- a/nbdserver/ardb/semideduped_test.go
+++ b/nbdserver/ardb/semideduped_test.go
@@ -150,34 +150,6 @@ func TestSemiDedupedContentBasic(t *testing.T) {
 	if content != nil {
 		t.Fatalf("unexpected content found: %v", content)
 	}
-
-	// let's merge template with user content
-	err = storage.Merge(templateIndexA, 1, userContentA)
-	if err != nil {
-		t.Fatalf("merging templateIndexA failed: %v", err)
-	}
-	// let's check if the merging went fine
-	content, err = storage.Get(templateIndexA)
-	if err != nil {
-		t.Fatalf("getting templateIndexA failed: %v", err)
-	}
-	if bytes.Compare([]byte{1, 4, 2, 4, 5, 6, 7, 8}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
-
-	// let's merge nil content with user content
-	err = storage.Merge(templateIndexB, 2, userContentA)
-	if err != nil {
-		t.Fatalf("merging templateIndexB failed: %v", err)
-	}
-	// let's check if the merging went fine
-	content, err = storage.Get(templateIndexB)
-	if err != nil {
-		t.Fatalf("getting templateIndexB failed: %v", err)
-	}
-	if bytes.Compare([]byte{0, 0, 4, 2, 0, 0, 0, 0}, content) != 0 {
-		t.Fatalf("unexpected content found: %v", content)
-	}
 }
 
 func init() {

--- a/nbdserver/ardb/storage.go
+++ b/nbdserver/ardb/storage.go
@@ -10,9 +10,9 @@ import (
 // used by the ArbdBackend for a particular vdisk
 type backendStorage interface {
 	Set(blockIndex int64, content []byte) (err error)
-	Merge(blockIndex, offset int64, content []byte) (err error)
 	Get(blockIndex int64) (content []byte, err error)
 	Delete(blockIndex int64) (err error)
+
 	Flush() (err error)
 
 	Close() (err error)

--- a/nbdserver/ardb/tlog.go
+++ b/nbdserver/ardb/tlog.go
@@ -167,42 +167,6 @@ func (tls *tlogStorage) set(blockIndex int64, content []byte) error {
 	return nil
 }
 
-// Merge implements backendStorage.Merge
-func (tls *tlogStorage) Merge(blockIndex, offset int64, content []byte) error {
-	tls.mux.Lock()
-	defer tls.mux.Unlock()
-
-	mergedContent, err := tls.merge(blockIndex, offset, content)
-	if err != nil {
-		return err
-	}
-
-	// store new content
-	return tls.set(blockIndex, mergedContent)
-}
-
-func (tls *tlogStorage) merge(blockIndex, offset int64, content []byte) ([]byte, error) {
-	mergedContent, err := tls.get(blockIndex)
-	if err != nil {
-		return nil, err
-	}
-
-	// ensure merge block is of the proper size,
-	// as to ensure a proper merge
-	if len(mergedContent) == 0 {
-		mergedContent = make([]byte, tls.blockSize)
-	} else if int64(len(mergedContent)) < tls.blockSize {
-		mc := make([]byte, tls.blockSize)
-		copy(mc, mergedContent)
-		mergedContent = mc
-	}
-
-	// merge new with old content
-	copy(mergedContent[offset:], content)
-
-	return mergedContent, nil
-}
-
 // Get implements backendStorage.Get
 func (tls *tlogStorage) Get(blockIndex int64) (content []byte, err error) {
 	tls.mux.Lock()

--- a/nbdserver/ardb/tlog_gap_test.go
+++ b/nbdserver/ardb/tlog_gap_test.go
@@ -95,12 +95,6 @@ func (ms *slowInMemoryStorage) Set(blockIndex int64, content []byte) error {
 	return ms.storage.Set(blockIndex, content)
 }
 
-// Merge implements backendStorage.Merge
-func (ms *slowInMemoryStorage) Merge(blockIndex, offset int64, content []byte) error {
-	time.Sleep(ms.modSleepTime)
-	return ms.storage.Merge(blockIndex, offset, content)
-}
-
 // Get implements backendStorage.Get
 func (ms *slowInMemoryStorage) Get(blockIndex int64) ([]byte, error) {
 	return ms.storage.Get(blockIndex)


### PR DESCRIPTION
each storage was implementing the Merge method pretty much the same,
so this commit simplifies the backendStorage by moving
the merge logic to the ardb.Backend