### PR TITLE
tlog : stop vdisk on failed flush.

### DIFF
--- a/nbd/nbdserver/backend.go
+++ b/nbd/nbdserver/backend.go
@@ -244,7 +244,7 @@ func (ab *backend) GoBackground(ctx context.Context) {
 		case err = <-done:
 			log.Infof("vdisk '%s' finished the flush under SIGTERM handler", ab.vdiskID)
 
-		case <-time.After(2 * time.Minute):
+		case <-time.After(flushWaitRetry * flushWaitRetryNum):
 			// TODO :
 			// - how long is the reasonable waiting time?
 			// - put this value in the config?

--- a/nbd/nbdserver/const.go
+++ b/nbd/nbdserver/const.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"time"
+)
+
+const (
+	flushWaitRetry    = time.Minute // retry flush after this timeout
+	flushWaitRetryNum = 4           // retry flush for this times
+)

--- a/tlog/tlogserver/server/server.go
+++ b/tlog/tlogserver/server/server.go
@@ -202,9 +202,6 @@ func (s *Server) writeHandshakeResponse(w io.Writer, segmentBuf []byte, status t
 func (s *Server) handle(conn *net.TCPConn) error {
 	defer conn.Close()
 
-	ctx, cancelFunc := context.WithCancel(context.Background())
-	defer cancelFunc()
-
 	br := bufio.NewReader(conn)
 
 	vdisk, err := s.handshake(br, conn, conn)
@@ -213,6 +210,9 @@ func (s *Server) handle(conn *net.TCPConn) error {
 		return err
 	}
 	defer vdisk.removeClient(conn)
+
+	ctx, cancelFunc := context.WithCancel(vdisk.ctx)
+	defer cancelFunc()
 
 	// start response sender
 	go s.sendResp(ctx, conn, vdisk.ID(), vdisk.ResponseChan())
@@ -294,12 +294,18 @@ func (s *Server) handleBlock(vd *vdisk, br *bufio.Reader) error {
 }
 
 // response sender for a vdisk
-func (s *Server) sendResp(ctx context.Context, w io.Writer, vdiskID string, respChan <-chan *BlockResponse) {
+func (s *Server) sendResp(ctx context.Context, conn *net.TCPConn, vdiskID string, respChan <-chan *BlockResponse) {
+	defer func() {
+		log.Infof("sendResp cleanup for vdisk %v", vdiskID)
+		conn.Close() // it will also close the receiver
+	}()
+
 	segmentBuf := make([]byte, 0, s.maxRespSegmentBufLen)
+
 	for {
 		select {
 		case resp := <-respChan:
-			if err := resp.Write(w, segmentBuf); err != nil {
+			if err := resp.Write(conn, segmentBuf); err != nil && resp != nil {
 				log.Infof("failed to send resp to :%v, err:%v", vdiskID, err)
 				return
 			}


### PR DESCRIPTION
So the client could move to other server.
Or reconnect again and then we retry the flush.

Part of #399