### PR TITLE
remove metadata storage cluster from 0-Disk

### DIFF
--- a/config/composition.go
+++ b/config/composition.go
@@ -20,7 +20,7 @@ type NBDStorageConfig struct {
 
 // Validate all properties of this config,
 // using the Storage Type information for the optional properties.
-func (cfg *NBDStorageConfig) Validate(storageType StorageType) error {
+func (cfg *NBDStorageConfig) Validate() error {
 	if cfg == nil {
 		return nil
 	}
@@ -31,18 +31,12 @@ func (cfg *NBDStorageConfig) Validate(storageType StorageType) error {
 		return fmt.Errorf(
 			"invalid NBDStorageConfig, invalid primary storage cluster: %v", err)
 	}
-	err = cfg.StorageCluster.ValidateStorageType(storageType)
-	if err != nil {
-		return fmt.Errorf("invalid NBDStorageConfig.PrimaryStorage: %v", err)
-	}
 
 	// ensure that if the template cluster is given, it is valid
-	if cfg.TemplateStorageCluster != nil {
-		err = cfg.TemplateStorageCluster.Validate()
-		if err != nil {
-			return fmt.Errorf(
-				"invalid NBDStorageConfig, invalid template storage cluster: %v", err)
-		}
+	err = cfg.TemplateStorageCluster.Validate()
+	if err != nil {
+		return fmt.Errorf(
+			"invalid NBDStorageConfig, invalid template storage cluster: %v", err)
 	}
 
 	// ensure that if the slave cluster is given, it is valid
@@ -60,12 +54,6 @@ func (cfg *NBDStorageConfig) Validate(storageType StorageType) error {
 		if slaveDataShardCount < primaryDataShardCount {
 			return errInsufficientSlaveDataShards
 		}
-
-		// ensure that the slave contains a metadata (storage) server if required
-		err = cfg.SlaveStorageCluster.ValidateStorageType(storageType)
-		if err != nil {
-			return fmt.Errorf("invalid NBDStorageConfig.SlaveStorage: %v", err)
-		}
 	}
 
 	return nil
@@ -75,37 +63,6 @@ var (
 	errInsufficientSlaveDataShards = errors.New("invalid NBDStorageConfig.SlaveStorage: insufficient slave data storage servers" +
 		" (require at least as much as the primary cluster has defined)")
 )
-
-// ValidateOptional validates the optional properties of this config,
-// using the Storage Type information.
-func (cfg *NBDStorageConfig) ValidateOptional(storageType StorageType) error {
-	// both deduped and semideduped storage types require
-	// a metadata server to be defined
-	if storageType == StorageNonDeduped {
-		return nil
-	}
-
-	return cfg.ValidateRequiredMetadataStorage()
-}
-
-// ValidateRequiredMetadataStorage allows you to ensure that the (slave) storage cluster
-// defines a valid Metadata Storage.
-func (cfg *NBDStorageConfig) ValidateRequiredMetadataStorage() error {
-	if cfg == nil {
-		return nil
-	}
-
-	if cfg.StorageCluster.MetadataStorage == nil {
-		return errors.New("invalid NBDStorageConfig: require a storage server for (primary) metadata")
-	}
-
-	if cfg.SlaveStorageCluster != nil && cfg.SlaveStorageCluster.MetadataStorage == nil {
-		return errors.New("invalid NBDStorageConfig: require a storage server for (slave) metadata")
-	}
-
-	// composed config is valid
-	return nil
-}
 
 // Clone this config
 func (cfg *NBDStorageConfig) Clone() NBDStorageConfig {
@@ -138,7 +95,7 @@ type TlogStorageConfig struct {
 
 // Validate the required properties of this config,
 // using the VdiskType information.
-func (cfg *TlogStorageConfig) Validate(storageType StorageType) error {
+func (cfg *TlogStorageConfig) Validate() error {
 	if cfg == nil {
 		return nil
 	}
@@ -150,33 +107,13 @@ func (cfg *TlogStorageConfig) Validate(storageType StorageType) error {
 			"invalid TlogStorageConfig, invalid 0-stor cluster: %v", err)
 	}
 
-	return cfg.ValidateOptional(storageType)
-}
-
-// ValidateOptional validates the optional properties of this config,
-// using the Storage Type information.
-func (cfg *TlogStorageConfig) ValidateOptional(storageType StorageType) error {
-	// both deduped and semideduped storage types require
-	// a metadata server to be defined for the slave cluster,
-	// if one is given
-	if cfg.SlaveStorageCluster != nil {
-		// ensure it is valid
-		err := cfg.SlaveStorageCluster.Validate()
-		if err != nil {
-			return fmt.Errorf(
-				"invalid TlogStorageConfig, invalid slave storage cluster: %v", err)
-		}
-
-		// both deduped and semideduped storage types require
-		// a metadata server to be defined
-		if storageType != StorageNonDeduped &&
-			cfg.SlaveStorageCluster.MetadataStorage == nil {
-			return fmt.Errorf(
-				"invalid TlogStorageConfig: storage type %s requires a storage server for slave metadata",
-				storageType)
-		}
+	// validate optional slave storage cluster
+	err = cfg.SlaveStorageCluster.Validate()
+	if err != nil {
+		return fmt.Errorf(
+			"invalid TlogStorageConfig, invalid slave storage cluster: %v", err)
 	}
 
-	// composed config is valid
+	// all valid
 	return nil
 }

--- a/config/composition.go
+++ b/config/composition.go
@@ -49,8 +49,8 @@ func (cfg *NBDStorageConfig) Validate() error {
 		}
 
 		// ensure that the slave cluster defines enough data (storage) servers
-		slaveDataShardCount := len(cfg.SlaveStorageCluster.DataStorage)
-		primaryDataShardCount := len(cfg.StorageCluster.DataStorage)
+		slaveDataShardCount := len(cfg.SlaveStorageCluster.Servers)
+		primaryDataShardCount := len(cfg.StorageCluster.Servers)
 		if slaveDataShardCount < primaryDataShardCount {
 			return errInsufficientSlaveDataShards
 		}

--- a/config/composition_api_test.go
+++ b/config/composition_api_test.go
@@ -12,7 +12,7 @@ import (
 func TestReadNBDStorageConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	_, err := ReadNBDStorageConfig(nil, "", nil)
+	_, err := ReadNBDStorageConfig(nil, "")
 	assert.Error(err, "should trigger error due to nil-source")
 
 	// create stub source, with no config, which will trigger errors
@@ -30,39 +30,33 @@ func TestReadNBDStorageConfig(t *testing.T) {
 		}
 	}
 
-	_, err = ReadNBDStorageConfig(source, "a", nil)
+	_, err = ReadNBDStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to nil config")
 
 	source.SetVdiskConfig("a", new(VdiskStaticConfig))
-	_, err = ReadNBDStorageConfig(source, "a", nil)
+	_, err = ReadNBDStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to invalid config")
 	testInvalidKey(Key{ID: "a", Type: KeyVdiskNBD})
 
 	source.SetVdiskConfig("a", nil) // delete it first, so we can properly create it by default
 	source.SetPrimaryStorageCluster("a", "mycluster", nil)
-	_, err = ReadNBDStorageConfig(source, "a", nil)
+	_, err = ReadNBDStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to nil reference")
 	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
 
 	source.SetStorageCluster("mycluster", new(StorageClusterConfig))
-	_, err = ReadNBDStorageConfig(source, "a", nil)
+	_, err = ReadNBDStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to invalid reference")
 	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
 
 	source.SetStorageCluster("mycluster", &StorageClusterConfig{
-		DataStorage:     []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
+		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 	})
-	nbdStorageCfg, err := ReadNBDStorageConfig(source, "a", nil)
+	nbdStorageCfg, err := ReadNBDStorageConfig(source, "a")
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(
 			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 			nbdStorageCfg.StorageCluster.DataStorage)
-		if assert.NotNil(nbdStorageCfg.StorageCluster.MetadataStorage) {
-			assert.Equal(
-				StorageServerConfig{Address: "localhost:16379"},
-				*nbdStorageCfg.StorageCluster.MetadataStorage)
-		}
 	}
 
 	source.SetTemplateStorageCluster("a", "templateCluster", &StorageClusterConfig{
@@ -72,16 +66,11 @@ func TestReadNBDStorageConfig(t *testing.T) {
 			StorageServerConfig{Address: "localhost:16382"},
 		},
 	})
-	nbdStorageCfg, err = ReadNBDStorageConfig(source, "a", nil)
+	nbdStorageCfg, err = ReadNBDStorageConfig(source, "a")
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(
 			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 			nbdStorageCfg.StorageCluster.DataStorage)
-		if assert.NotNil(nbdStorageCfg.StorageCluster.MetadataStorage) {
-			assert.Equal(
-				StorageServerConfig{Address: "localhost:16379"},
-				*nbdStorageCfg.StorageCluster.MetadataStorage)
-		}
 		if assert.NotNil(nbdStorageCfg.TemplateStorageCluster) {
 			assert.Equal(
 				[]StorageServerConfig{
@@ -94,12 +83,12 @@ func TestReadNBDStorageConfig(t *testing.T) {
 	}
 
 	source.SetSlaveStorageCluster("a", "slaveCluster", nil)
-	_, err = ReadNBDStorageConfig(source, "a", nil)
+	_, err = ReadNBDStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to nil slave cluster")
 	testInvalidKey(Key{ID: "slaveCluster", Type: KeyClusterStorage})
 
 	source.SetSlaveStorageCluster("a", "slaveCluster", new(StorageClusterConfig))
-	_, err = ReadNBDStorageConfig(source, "a", nil)
+	_, err = ReadNBDStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to invalid slave cluster")
 	testInvalidKey(Key{ID: "slaveCluster", Type: KeyClusterStorage})
 
@@ -109,28 +98,12 @@ func TestReadNBDStorageConfig(t *testing.T) {
 			StorageServerConfig{Address: "localhost:16380"},
 		},
 	})
-	_, err = ReadNBDStorageConfig(source, "a", nil)
-	assert.Error(err, "should trigger error due to invalid slave cluster (missing metadata)")
-	testInvalidKey(Key{ID: "slaveCluster", Type: KeyClusterStorage})
 
-	source.SetSlaveStorageCluster("a", "slaveCluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
-			StorageServerConfig{Address: "localhost:16379"},
-			StorageServerConfig{Address: "localhost:16380"},
-		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
-	})
-
-	nbdStorageCfg, err = ReadNBDStorageConfig(source, "a", nil)
+	nbdStorageCfg, err = ReadNBDStorageConfig(source, "a")
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(
 			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 			nbdStorageCfg.StorageCluster.DataStorage)
-		if assert.NotNil(nbdStorageCfg.StorageCluster.MetadataStorage) {
-			assert.Equal(
-				StorageServerConfig{Address: "localhost:16379"},
-				*nbdStorageCfg.StorageCluster.MetadataStorage)
-		}
 		if assert.NotNil(nbdStorageCfg.TemplateStorageCluster) {
 			assert.Equal(
 				[]StorageServerConfig{
@@ -147,137 +120,6 @@ func TestReadNBDStorageConfig(t *testing.T) {
 					StorageServerConfig{Address: "localhost:16380"},
 				},
 				nbdStorageCfg.SlaveStorageCluster.DataStorage)
-			if assert.NotNil(nbdStorageCfg.SlaveStorageCluster.MetadataStorage) {
-				assert.Equal(
-					StorageServerConfig{Address: "localhost:16379"},
-					*nbdStorageCfg.SlaveStorageCluster.MetadataStorage)
-			}
-		}
-	}
-}
-
-func TestReadNBDStorageConfigWithTlogSupport(t *testing.T) {
-	assert := assert.New(t)
-
-	// create stub source, with no config, which will trigger errors
-	source := NewStubSource()
-
-	invalidKeyCh := source.InvalidKey()
-	testInvalidKey := func(expected Key) {
-		select {
-		case invalidKey := <-invalidKeyCh:
-			if !assert.Equal(expected, invalidKey) {
-				assert.FailNow("unexpected invalid key", "%v", invalidKey)
-			}
-		case <-time.After(time.Second):
-			assert.FailNow("timed out while waiting for invalid key", "%v", expected)
-		}
-	}
-
-	// even though nonDeduped storages don't have metadata storage,
-	// in case it has tlog support and it actually makes use of it,
-	// we also require a metadata server for primary (and if defined slave) cluster(s).
-	source.SetVdiskConfig("nd", &VdiskStaticConfig{
-		BlockSize: 4096,
-		Size:      10,
-		Type:      VdiskTypeDB,
-	})
-
-	source.SetPrimaryStorageCluster("nd", "mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-	})
-	nbdStorageCfg, err := ReadNBDStorageConfig(source, "nd", nil)
-	if assert.NoError(err, "should be fine, as no tlog hase been configured") {
-		assert.Equal(
-			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
-		assert.Nil(nbdStorageCfg.StorageCluster.MetadataStorage)
-		assert.Nil(nbdStorageCfg.SlaveStorageCluster)
-	}
-	// now set a tlog storage cluster ID
-	source.SetTlogServerCluster("nd", "tlogcluster", &TlogClusterConfig{
-		Servers: []string{
-			"localhost:20003",
-		},
-	})
-	_, err = ReadNBDStorageConfig(source, "nd", nil)
-	if assert.Error(err, "should error, as no metadata server is defined even though we have a tlog-storage") {
-		testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
-	}
-	// Now set the metadata storage for the primary cluster, this should make the read valid
-	source.SetStorageCluster("mycluster", &StorageClusterConfig{
-		DataStorage:     []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16378"},
-	})
-	nbdStorageCfg, err = ReadNBDStorageConfig(source, "nd", nil)
-	if assert.NoError(err, "should be fine, as primary cluster has a metadata storage server defined") {
-		assert.Equal(
-			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
-		if assert.NotNil(nbdStorageCfg.StorageCluster.MetadataStorage) {
-			assert.Equal(
-				StorageServerConfig{Address: "localhost:16378"},
-				*nbdStorageCfg.StorageCluster.MetadataStorage)
-		}
-		assert.Nil(nbdStorageCfg.SlaveStorageCluster)
-	}
-
-	// now let's remove the tlog support again and add a slave cluster
-	source.SetTlogServerCluster("nd", "", nil)
-	source.SetSlaveStorageCluster("nd", "slavecluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:17379"}},
-	})
-	nbdStorageCfg, err = ReadNBDStorageConfig(source, "nd", nil)
-	if assert.NoError(err, "should be fine, as no tlog cluster is defined") {
-		assert.Equal(
-			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
-		if assert.NotNil(nbdStorageCfg.StorageCluster.MetadataStorage) {
-			assert.Equal(
-				StorageServerConfig{Address: "localhost:16378"},
-				*nbdStorageCfg.StorageCluster.MetadataStorage)
-		}
-		if assert.NotNil(nbdStorageCfg.SlaveStorageCluster) {
-			assert.Equal(
-				[]StorageServerConfig{StorageServerConfig{Address: "localhost:17379"}},
-				nbdStorageCfg.SlaveStorageCluster.DataStorage)
-			assert.Nil(nbdStorageCfg.SlaveStorageCluster.MetadataStorage)
-		}
-	}
-
-	source.SetTlogServerCluster("nd", "tlogcluster", nil)
-	// adding the tlogcluster back will make the reading now fail,
-	// as the slave cluster defined for our vdisk does not define a metadata storage cluster,
-	// even though it is required for the tlogStorage's metadata storage
-	_, err = ReadNBDStorageConfig(source, "nd", nil)
-	if assert.Error(err, "should error, as no metadata server is defined for slave cluster even though we have a tlog-storage") {
-		testInvalidKey(Key{ID: "slavecluster", Type: KeyClusterStorage})
-	}
-
-	// Now set the metadata storage for the slave cluster, this should make the read valid
-	source.SetStorageCluster("slavecluster", &StorageClusterConfig{
-		DataStorage:     []StorageServerConfig{StorageServerConfig{Address: "localhost:17379"}},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:17378"},
-	})
-	nbdStorageCfg, err = ReadNBDStorageConfig(source, "nd", nil)
-	if assert.NoError(err, "should be fine, both slave and primary clusters definea  metadata storage server") {
-		assert.Equal(
-			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
-		if assert.NotNil(nbdStorageCfg.StorageCluster.MetadataStorage) {
-			assert.Equal(
-				StorageServerConfig{Address: "localhost:16378"},
-				*nbdStorageCfg.StorageCluster.MetadataStorage)
-		}
-		if assert.NotNil(nbdStorageCfg.SlaveStorageCluster) {
-			assert.Equal(
-				[]StorageServerConfig{StorageServerConfig{Address: "localhost:17379"}},
-				nbdStorageCfg.SlaveStorageCluster.DataStorage)
-			if assert.NotNil(nbdStorageCfg.SlaveStorageCluster.MetadataStorage) {
-				assert.Equal(
-					StorageServerConfig{Address: "localhost:17378"},
-					*nbdStorageCfg.SlaveStorageCluster.MetadataStorage)
-			}
 		}
 	}
 }
@@ -285,7 +127,7 @@ func TestReadNBDStorageConfigWithTlogSupport(t *testing.T) {
 func TestReadTlogStorageConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	_, err := ReadTlogStorageConfig(nil, "", nil)
+	_, err := ReadTlogStorageConfig(nil, "")
 	assert.Error(err, "should trigger error due to nil-source")
 
 	// create stub source, with no config, which will trigger errors
@@ -303,18 +145,18 @@ func TestReadTlogStorageConfig(t *testing.T) {
 		}
 	}
 
-	_, err = ReadTlogStorageConfig(source, "a", nil)
+	_, err = ReadTlogStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to nil config")
 
 	source.SetVdiskConfig("a", new(VdiskStaticConfig))
-	_, err = ReadTlogStorageConfig(source, "a", nil)
+	_, err = ReadTlogStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to invalid config")
 	testInvalidKey(Key{ID: "a", Type: KeyVdiskTlog})
 
 	source.SetVdiskConfig("a", nil) // delete it first, so we can properly create it by default
 
 	source.SetTlogZeroStorCluster("a", "mycluster", new(ZeroStorClusterConfig))
-	_, err = ReadTlogStorageConfig(source, "a", nil)
+	_, err = ReadTlogStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to invalid reference")
 	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterZeroStor})
 
@@ -330,7 +172,7 @@ func TestReadTlogStorageConfig(t *testing.T) {
 		MetadataServers: []ServerConfig{ServerConfig{"2.2.2.2:22"}},
 	}
 	source.SetTlogZeroStorCluster("a", "mycluster", &originalZeroStorCfg)
-	tlogStorCfg, err := ReadTlogStorageConfig(source, "a", nil)
+	tlogStorCfg, err := ReadTlogStorageConfig(source, "a")
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(originalZeroStorCfg, tlogStorCfg.ZeroStorCluster)
 	}
@@ -338,11 +180,11 @@ func TestReadTlogStorageConfig(t *testing.T) {
 	// add nil slave cluster
 	source.SetSlaveStorageCluster("a", "slaveCluster", nil)
 
-	_, err = ReadTlogStorageConfig(source, "a", nil)
+	_, err = ReadTlogStorageConfig(source, "a")
 	assert.Error(err, "should trigger error due to nil slave cluster")
 	testInvalidKey(Key{ID: "slaveCluster", Type: KeyClusterStorage})
 
-	// add invalid slave cluster
+	// add slave cluster
 	slaveClusterCfg := StorageClusterConfig{
 		DataStorage: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:3000"},
@@ -351,15 +193,7 @@ func TestReadTlogStorageConfig(t *testing.T) {
 	}
 	source.SetSlaveStorageCluster("a", "slaveCluster", &slaveClusterCfg)
 
-	_, err = ReadTlogStorageConfig(source, "a", nil)
-	assert.Error(err, "should trigger error due to invalid slave cluster")
-	testInvalidKey(Key{ID: "slaveCluster", Type: KeyClusterStorage})
-
-	// add valid slave cluster
-	slaveClusterCfg.MetadataStorage = &StorageServerConfig{Address: "localhost:2030"}
-	source.SetSlaveStorageCluster("a", "slaveCluster", &slaveClusterCfg)
-
-	tlogStorCfg, err = ReadTlogStorageConfig(source, "a", nil)
+	tlogStorCfg, err = ReadTlogStorageConfig(source, "a")
 	if assert.NoError(err, "should be fine as both the vdisk and storages are properly configured") {
 		assert.Equal(originalZeroStorCfg, tlogStorCfg.ZeroStorCluster)
 		assert.Equal(slaveClusterCfg, *tlogStorCfg.SlaveStorageCluster)
@@ -400,21 +234,11 @@ func TestWatchNBDStorageConfig_FailAtStartup(t *testing.T) {
 	assert.Error(err, "should trigger error due to missing/nil configs")
 	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
 
-	source.SetStorageCluster("mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
-			StorageServerConfig{Address: "localhost:16379"},
-		},
-	})
-	_, err = WatchNBDStorageConfig(ctx, source, "a")
-	assert.Error(err, "should trigger error due to missing metadata storage")
-	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
-
 	// last one is golden
 	source.SetStorageCluster("mycluster", &StorageClusterConfig{
 		DataStorage: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
 	})
 	_, err = WatchNBDStorageConfig(ctx, source, "a")
 	assert.NoError(err, "should be fine now")
@@ -432,7 +256,6 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 		DataStorage: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
 	})
 	ch, err := WatchNBDStorageConfig(ctx, source, "a")
 	if !assert.NoError(err, "should be valid") {
@@ -453,8 +276,6 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 
 	output := <-ch
 	assert.Nil(output.TemplateStorageCluster)
-	assert.Equal(
-		StorageServerConfig{Address: "localhost:16379"}, *output.StorageCluster.MetadataStorage)
 	if assert.Len(output.StorageCluster.DataStorage, 1) {
 		assert.Equal(
 			StorageServerConfig{Address: "localhost:16379"},
@@ -470,14 +291,11 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 		DataStorage: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16380"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16381"},
 	})
 
 	// trigger reload (even though it was broken before)
 	output = <-ch
 	assert.Nil(output.TemplateStorageCluster)
-	assert.Equal(
-		StorageServerConfig{Address: "localhost:16381"}, *output.StorageCluster.MetadataStorage)
 	if assert.Len(output.StorageCluster.DataStorage, 1) {
 		assert.Equal(
 			StorageServerConfig{Address: "localhost:16380"},
@@ -494,7 +312,6 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 		DataStorage: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
 	}
 
 	var templateStoragecluster *StorageClusterConfig
@@ -546,7 +363,6 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 		DataStorage: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16381"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16381"},
 	}
 
 	// now let's actually set the storage cluster
@@ -559,19 +375,8 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 			StorageServerConfig{Address: "231.201.201.200:2000"},
 			StorageServerConfig{Address: "231.201.201.200:2020"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "123.123.13.13:40"},
 	}
 	source.SetTemplateStorageCluster("a", "master", templateStoragecluster)
-	testValue()
-
-	// metadata server is not required for template storage
-	templateStoragecluster.MetadataStorage = nil
-	source.SetStorageCluster("master", templateStoragecluster)
-	testValue()
-
-	// but can be given, and it will be ignored by any user
-	templateStoragecluster.MetadataStorage = &StorageServerConfig{Address: "localhost:300"}
-	source.SetStorageCluster("master", templateStoragecluster)
 	testValue()
 
 	// now let's set slave cluster
@@ -580,19 +385,8 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 			StorageServerConfig{Address: "slave:200"},
 			StorageServerConfig{Address: "slave:201"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "slave:200", Database: 42},
 	}
 	source.SetSlaveStorageCluster("a", "slave", slaveStoragecluster)
-	testValue()
-
-	// metadata server is required for slave storage
-	slaveStoragecluster.MetadataStorage = nil
-	source.SetStorageCluster("slave", slaveStoragecluster)
-	testInvalidKey(Key{ID: "slave", Type: KeyClusterStorage}) // error value should not be updated
-
-	// even after, error, we can set a good value
-	slaveStoragecluster.MetadataStorage = &StorageServerConfig{Address: "localhost:300"}
-	source.SetStorageCluster("slave", slaveStoragecluster)
 	testValue()
 
 	// do another stupid illegal action
@@ -600,28 +394,13 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 	// trigger reload
 	testInvalidKey(Key{ID: "primary", Type: KeyClusterStorage}) // error value should not be updated
 
-	primaryStorageCluster.MetadataStorage.Database = 3
+	primaryStorageCluster.DataStorage[0].Database = 3
 	source.SetStorageCluster("primary", primaryStorageCluster)
 	testValue() // updating a storage cluster should be ok
 
 	templateStoragecluster = nil
 	source.SetTemplateStorageCluster("a", "", templateStoragecluster)
 	testValue() // and template storage cluster can even be dereferenced
-
-	// when updating a cluster, which makes the cluster not valid for the used vdisk,
-	// it should not apply the update either
-	primaryStorageCluster.MetadataStorage = nil
-	source.SetStorageCluster("primary", primaryStorageCluster)
-	testInvalidKey(Key{ID: "primary", Type: KeyClusterStorage}) // no update should happen
-
-	// updating a cluster in a valid way should still be possible
-	primaryStorageCluster.MetadataStorage = &StorageServerConfig{
-		Address: "localhost:16379", Database: 2,
-	}
-	primaryStorageCluster.DataStorage = append(primaryStorageCluster.DataStorage,
-		StorageServerConfig{Address: "localhost:2000", Database: 5})
-	source.SetStorageCluster("primary", primaryStorageCluster)
-	testValue() // updating a storage cluster should be ok
 
 	// cancel context
 	cancel()
@@ -634,124 +413,6 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 			assert.FailNow("channel should have been closed")
 		}
 	}
-}
-
-func TestWatchNBDStorageConfig_WithTlogSupport(t *testing.T) {
-	assert := assert.New(t)
-
-	source := NewStubSource()
-
-	// even though nonDeduped storages don't have metadata storage,
-	// in case it has tlog support and it actually makes use of it,
-	// we also require a metadata server for primary (and if defined slave) cluster(s).
-	source.SetVdiskConfig("nd", &VdiskStaticConfig{
-		BlockSize: 4096,
-		Size:      10,
-		Type:      VdiskTypeDB,
-	})
-
-	primaryStorageCluster := &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-	}
-	source.SetPrimaryStorageCluster("nd", "mycluster", primaryStorageCluster)
-	source.SetTlogServerCluster("nd", "tlogcluster", &TlogClusterConfig{
-		Servers: []string{"localhost:20003"},
-	})
-
-	var templateStoragecluster *StorageClusterConfig
-	var slaveStoragecluster *StorageClusterConfig
-
-	var ch <-chan NBDStorageConfig
-
-	invalidKeyCh := source.InvalidKey()
-	testInvalidKey := func(expected Key) {
-		select {
-		case invalidKey := <-invalidKeyCh:
-			if !assert.Equal(expected, invalidKey) {
-				assert.FailNow("unexpected invalid key", "%v", invalidKey)
-			}
-		case output := <-ch:
-			assert.FailNow("received unexpected value", "%v", output)
-		case <-time.After(time.Second):
-			assert.FailNow("timed out while waiting for invalid key", "%v", expected)
-		}
-	}
-
-	testValue := func() {
-		select {
-		case output := <-ch:
-			assert.True(output.StorageCluster.Equal(primaryStorageCluster),
-				"unexpected primary cluster: %v", output.StorageCluster)
-			assert.True(output.TemplateStorageCluster.Equal(templateStoragecluster),
-				"unexpected template cluster: %v", output.TemplateStorageCluster)
-			assert.True(output.SlaveStorageCluster.Equal(slaveStoragecluster),
-				"unexpected slave cluster: %v", output.SlaveStorageCluster)
-		case invalidKey := <-invalidKeyCh:
-			assert.FailNow("received unexpected invalid key", "%v", invalidKey)
-		case <-time.After(time.Second):
-			assert.FailNow("timed out while waiting for output or invalid key")
-		}
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	_, err := WatchNBDStorageConfig(ctx, source, "nd")
-	if assert.Error(err, "expected error due to no metadata server defined for primary cluster") {
-		testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
-	}
-
-	// define metadata storage server for the primary cluster to make it valid
-	primaryStorageCluster.MetadataStorage = &StorageServerConfig{Address: "localhost:16378"}
-	source.SetStorageCluster("mycluster", primaryStorageCluster)
-	// now let's start watching, we're ready!
-	ch, err = WatchNBDStorageConfig(ctx, source, "nd")
-	if !assert.NoError(err) {
-		return
-	}
-
-	testValue()
-
-	// now let's try to reload with an invalid slave cluster
-	slaveStoragecluster = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
-			StorageServerConfig{Address: "localhost:17379"},
-		},
-	}
-	source.SetSlaveStorageCluster("nd", "slavecluster", slaveStoragecluster)
-	testInvalidKey(Key{ID: "slavecluster", Type: KeyClusterStorage})
-
-	// now add metadata storage server for slave, which should make it possible to use it
-	slaveStoragecluster.MetadataStorage = &StorageServerConfig{Address: "localhost:17378"}
-	source.SetSlaveStorageCluster("nd", "slavecluster", slaveStoragecluster)
-	testValue()
-
-	// remove tlogcluster, should be fine as that just makes metadata cluster to be ignored
-	source.SetTlogServerCluster("nd", "", nil)
-
-	// now update slave cluster by removing metadata server
-	slaveStoragecluster.MetadataStorage = nil
-	source.SetStorageCluster("slavecluster", slaveStoragecluster)
-	testValue()
-
-	// now update primary cluster by removing metadata server
-	primaryStorageCluster.MetadataStorage = nil
-	source.SetStorageCluster("mycluster", primaryStorageCluster)
-	testValue()
-
-	// remove slave cluster
-	slaveStoragecluster = nil
-	source.SetSlaveStorageCluster("nd", "", slaveStoragecluster)
-	testValue()
-
-	// add tlogcluster
-	source.SetTlogServerCluster("nd", "tlogcluster", nil)
-	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
-
-	// fix primary cluster, should work again
-	primaryStorageCluster.MetadataStorage = &StorageServerConfig{Address: "localhost:16378"}
-	source.SetStorageCluster("mycluster", primaryStorageCluster)
-	testValue()
 }
 
 func TestWatchTlogStorageConfig_FailAtStartup(t *testing.T) {
@@ -944,18 +605,8 @@ func TestWatchTlogStorageConfig_ChangeClusterReference(t *testing.T) {
 			StorageServerConfig{Address: "231.201.201.200:2000"},
 			StorageServerConfig{Address: "231.201.201.200:2020"},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "123.123.13.13:40"},
 	}
 	source.SetSlaveStorageCluster("a", "slave", slaveStoragecluster)
-	testValue()
-
-	// setting an invalid slave Storage cluster should not be possible
-	slaveStoragecluster.MetadataStorage = nil
-	source.SetStorageCluster("slave", slaveStoragecluster)
-	testInvalidKey(Key{ID: "slave", Type: KeyClusterStorage}) // error value should not be updated
-
-	slaveStoragecluster.MetadataStorage = &StorageServerConfig{Address: "localhost:300"}
-	source.SetStorageCluster("slave", slaveStoragecluster)
 	testValue()
 
 	// do another stupid illegal action

--- a/config/composition_api_test.go
+++ b/config/composition_api_test.go
@@ -50,17 +50,17 @@ func TestReadNBDStorageConfig(t *testing.T) {
 	testInvalidKey(Key{ID: "mycluster", Type: KeyClusterStorage})
 
 	source.SetStorageCluster("mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
+		Servers: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 	})
 	nbdStorageCfg, err := ReadNBDStorageConfig(source, "a")
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(
 			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
+			nbdStorageCfg.StorageCluster.Servers)
 	}
 
 	source.SetTemplateStorageCluster("a", "templateCluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16380"},
 			StorageServerConfig{Address: "localhost:16381"},
 			StorageServerConfig{Address: "localhost:16382"},
@@ -70,7 +70,7 @@ func TestReadNBDStorageConfig(t *testing.T) {
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(
 			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
+			nbdStorageCfg.StorageCluster.Servers)
 		if assert.NotNil(nbdStorageCfg.TemplateStorageCluster) {
 			assert.Equal(
 				[]StorageServerConfig{
@@ -78,7 +78,7 @@ func TestReadNBDStorageConfig(t *testing.T) {
 					StorageServerConfig{Address: "localhost:16381"},
 					StorageServerConfig{Address: "localhost:16382"},
 				},
-				nbdStorageCfg.TemplateStorageCluster.DataStorage)
+				nbdStorageCfg.TemplateStorageCluster.Servers)
 		}
 	}
 
@@ -93,7 +93,7 @@ func TestReadNBDStorageConfig(t *testing.T) {
 	testInvalidKey(Key{ID: "slaveCluster", Type: KeyClusterStorage})
 
 	source.SetSlaveStorageCluster("a", "slaveCluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 			StorageServerConfig{Address: "localhost:16380"},
 		},
@@ -103,7 +103,7 @@ func TestReadNBDStorageConfig(t *testing.T) {
 	if assert.NoError(err, "should be fine as both the vdisk and storage are properly configured") {
 		assert.Equal(
 			[]StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-			nbdStorageCfg.StorageCluster.DataStorage)
+			nbdStorageCfg.StorageCluster.Servers)
 		if assert.NotNil(nbdStorageCfg.TemplateStorageCluster) {
 			assert.Equal(
 				[]StorageServerConfig{
@@ -111,7 +111,7 @@ func TestReadNBDStorageConfig(t *testing.T) {
 					StorageServerConfig{Address: "localhost:16381"},
 					StorageServerConfig{Address: "localhost:16382"},
 				},
-				nbdStorageCfg.TemplateStorageCluster.DataStorage)
+				nbdStorageCfg.TemplateStorageCluster.Servers)
 		}
 		if assert.NotNil(nbdStorageCfg.SlaveStorageCluster) {
 			assert.Equal(
@@ -119,7 +119,7 @@ func TestReadNBDStorageConfig(t *testing.T) {
 					StorageServerConfig{Address: "localhost:16379"},
 					StorageServerConfig{Address: "localhost:16380"},
 				},
-				nbdStorageCfg.SlaveStorageCluster.DataStorage)
+				nbdStorageCfg.SlaveStorageCluster.Servers)
 		}
 	}
 }
@@ -186,7 +186,7 @@ func TestReadTlogStorageConfig(t *testing.T) {
 
 	// add slave cluster
 	slaveClusterCfg := StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:3000"},
 			StorageServerConfig{Address: "localhost:3002", Database: 42},
 		},
@@ -236,7 +236,7 @@ func TestWatchNBDStorageConfig_FailAtStartup(t *testing.T) {
 
 	// last one is golden
 	source.SetStorageCluster("mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
 	})
@@ -253,7 +253,7 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 	source := NewStubSource()
 
 	source.SetPrimaryStorageCluster("a", "mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
 	})
@@ -276,10 +276,10 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 
 	output := <-ch
 	assert.Nil(output.TemplateStorageCluster)
-	if assert.Len(output.StorageCluster.DataStorage, 1) {
+	if assert.Len(output.StorageCluster.Servers, 1) {
 		assert.Equal(
 			StorageServerConfig{Address: "localhost:16379"},
-			output.StorageCluster.DataStorage[0])
+			output.StorageCluster.Servers[0])
 	}
 
 	// now let's break it
@@ -288,7 +288,7 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 
 	// now let's fix it again
 	source.SetStorageCluster("mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16380"},
 		},
 	})
@@ -296,10 +296,10 @@ func TestWatchNBDStorageConfig_FailAfterSuccess(t *testing.T) {
 	// trigger reload (even though it was broken before)
 	output = <-ch
 	assert.Nil(output.TemplateStorageCluster)
-	if assert.Len(output.StorageCluster.DataStorage, 1) {
+	if assert.Len(output.StorageCluster.Servers, 1) {
 		assert.Equal(
 			StorageServerConfig{Address: "localhost:16380"},
-			output.StorageCluster.DataStorage[0])
+			output.StorageCluster.Servers[0])
 	}
 }
 
@@ -309,7 +309,7 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 	source := NewStubSource()
 
 	primaryStorageCluster := &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
 	}
@@ -360,7 +360,7 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 	testInvalidKey(Key{ID: "foocluster", Type: KeyClusterStorage}) // error value should not be updated
 
 	primaryStorageCluster = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16381"},
 		},
 	}
@@ -371,7 +371,7 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 
 	// now let's set template cluster
 	templateStoragecluster = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "231.201.201.200:2000"},
 			StorageServerConfig{Address: "231.201.201.200:2020"},
 		},
@@ -381,7 +381,7 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 
 	// now let's set slave cluster
 	slaveStoragecluster = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "slave:200"},
 			StorageServerConfig{Address: "slave:201"},
 		},
@@ -394,7 +394,7 @@ func TestWatchNBDStorageConfig_ChangeClusterReference(t *testing.T) {
 	// trigger reload
 	testInvalidKey(Key{ID: "primary", Type: KeyClusterStorage}) // error value should not be updated
 
-	primaryStorageCluster.DataStorage[0].Database = 3
+	primaryStorageCluster.Servers[0].Database = 3
 	source.SetStorageCluster("primary", primaryStorageCluster)
 	testValue() // updating a storage cluster should be ok
 
@@ -601,7 +601,7 @@ func TestWatchTlogStorageConfig_ChangeClusterReference(t *testing.T) {
 
 	// now let's set template cluster
 	slaveStoragecluster = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "231.201.201.200:2000"},
 			StorageServerConfig{Address: "231.201.201.200:2020"},
 		},

--- a/config/composition_data_test.go
+++ b/config/composition_data_test.go
@@ -4,7 +4,7 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 	// complete example
 	NBDStorageConfig{
 		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address:  "localhost:16379",
 					Database: 1,
@@ -16,7 +16,7 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 			},
 		},
 		TemplateStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address:  "123.123.123.123:300",
 					Database: 4,
@@ -28,7 +28,7 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 			},
 		},
 		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address:  "foo:16320",
 					Database: 4,
@@ -43,7 +43,7 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 	// example to show that there can be more data slave servers than required
 	NBDStorageConfig{
 		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address:  "localhost:16379",
 					Database: 1,
@@ -51,7 +51,7 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 			},
 		},
 		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address:  "foo:16320",
 					Database: 4,
@@ -66,7 +66,7 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 	// minimal example
 	NBDStorageConfig{
 		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address: "localhost:16379",
 				},
@@ -85,7 +85,7 @@ var invalidNBDStorageConfigs = []NBDStorageConfig{
 	// template storage given, but is invalid
 	NBDStorageConfig{
 		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{Address: "localhost:16381"},
 			},
 		},
@@ -94,7 +94,7 @@ var invalidNBDStorageConfigs = []NBDStorageConfig{
 	// slave storage given, but is invalid (no data servers given)
 	NBDStorageConfig{
 		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{Address: "localhost:16381"},
 			},
 		},
@@ -103,13 +103,13 @@ var invalidNBDStorageConfigs = []NBDStorageConfig{
 	// slave storage given, but is invalid (not enough data servers given)
 	NBDStorageConfig{
 		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{Address: "localhost:16381"},
 				StorageServerConfig{Address: "localhost:16382"},
 			},
 		},
 		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{Address: "localhost:16383"},
 			},
 		},
@@ -120,7 +120,7 @@ var validTlogStorageConfigs = []TlogStorageConfig{
 	// complete example
 	TlogStorageConfig{
 		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address:  "localhost:16379",
 					Database: 1,
@@ -224,7 +224,7 @@ var invalidTlogStorageConfigsDeduped = append(invalidTlogStorageConfigs,
 			},
 		},
 		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
+			Servers: []StorageServerConfig{
 				StorageServerConfig{
 					Address: "localhost:16379",
 				},

--- a/config/composition_data_test.go
+++ b/config/composition_data_test.go
@@ -75,77 +75,12 @@ var validNBDStorageConfigs = []NBDStorageConfig{
 	},
 }
 
-var validNBDStorageConfigsDeduped = []NBDStorageConfig{
-	// complete example
-	NBDStorageConfig{
-		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{
-					Address:  "localhost:16379",
-					Database: 1,
-				},
-				StorageServerConfig{
-					Address:  "localhost:16380",
-					Database: 2,
-				},
-			},
-			MetadataStorage: &StorageServerConfig{
-				Address:  "localhost:16378",
-				Database: 4,
-			},
-		},
-		TemplateStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{
-					Address:  "123.123.123.123:300",
-					Database: 3,
-				},
-				StorageServerConfig{
-					Address:  "123.123.123.124:300",
-					Database: 6,
-				},
-			},
-		},
-		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{
-					Address:  "slave:16379",
-					Database: 5,
-				},
-				StorageServerConfig{
-					Address:  "slave:16380",
-					Database: 3,
-				},
-			},
-			MetadataStorage: &StorageServerConfig{
-				Address:  "slave:16378",
-				Database: 1,
-			},
-		},
-	},
-	// minimal example
-	NBDStorageConfig{
-		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{
-					Address: "localhost:16379",
-				},
-			},
-			MetadataStorage: &StorageServerConfig{
-				Address: "localhost:16379",
-			},
-		},
-	},
-}
-
 var invalidNBDStorageConfigs = []NBDStorageConfig{
 	// missing primary storage server
 	NBDStorageConfig{},
 	// invalid primary storage server (no data storage given)
 	NBDStorageConfig{
-		StorageCluster: StorageClusterConfig{
-			MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
-		},
+		StorageCluster: StorageClusterConfig{},
 	},
 	// template storage given, but is invalid
 	NBDStorageConfig{
@@ -181,32 +116,6 @@ var invalidNBDStorageConfigs = []NBDStorageConfig{
 	},
 }
 
-var invalidNBDStorageConfigsDeduped = append(invalidNBDStorageConfigs,
-	// missing metadata server (primary)
-	NBDStorageConfig{
-		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{Address: "localhost:16379"},
-			},
-		},
-	},
-	// missing metadata server (slave)
-	NBDStorageConfig{
-		StorageCluster: StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{Address: "localhost:16379"},
-			},
-			MetadataStorage: &StorageServerConfig{
-				Address: "localhost:16379",
-			},
-		},
-		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{Address: "localhost:16379"},
-			},
-		},
-	})
-
 var validTlogStorageConfigs = []TlogStorageConfig{
 	// complete example
 	TlogStorageConfig{
@@ -220,61 +129,6 @@ var validTlogStorageConfigs = []TlogStorageConfig{
 					Address:  "localhost:16380",
 					Database: 2,
 				},
-			},
-		},
-		ZeroStorCluster: ZeroStorClusterConfig{
-			IYO: IYOCredentials{
-				Org:       "foo org",
-				Namespace: "foo namespace",
-				ClientID:  "foo client",
-				Secret:    "foo secret",
-			},
-			Servers: []ServerConfig{
-				ServerConfig{Address: "1.1.1.1:11"},
-				ServerConfig{Address: "2.2.2.2:22"},
-			},
-			MetadataServers: []ServerConfig{
-				ServerConfig{Address: "3.3.3.3:33"},
-			},
-		},
-	},
-	// minimal example
-	TlogStorageConfig{
-		ZeroStorCluster: ZeroStorClusterConfig{
-			IYO: IYOCredentials{
-				Org:       "foo org",
-				Namespace: "foo namespace",
-				ClientID:  "foo client",
-				Secret:    "foo secret",
-			},
-			Servers: []ServerConfig{
-				ServerConfig{Address: "1.1.1.1:11"},
-				ServerConfig{Address: "2.2.2.2:22"},
-			},
-			MetadataServers: []ServerConfig{
-				ServerConfig{Address: "3.3.3.3:33"},
-			},
-		},
-	},
-}
-
-var validTlogStorageConfigsDeduped = []TlogStorageConfig{
-	// complete example
-	TlogStorageConfig{
-		SlaveStorageCluster: &StorageClusterConfig{
-			DataStorage: []StorageServerConfig{
-				StorageServerConfig{
-					Address:  "localhost:16379",
-					Database: 1,
-				},
-				StorageServerConfig{
-					Address:  "localhost:16380",
-					Database: 2,
-				},
-			},
-			MetadataStorage: &StorageServerConfig{
-				Address:  "localhost:42",
-				Database: 5,
 			},
 		},
 		ZeroStorCluster: ZeroStorClusterConfig{

--- a/config/composition_test.go
+++ b/config/composition_test.go
@@ -6,64 +6,32 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNBDStorageConfigValidateNonDeduped(t *testing.T) {
+func TestNBDStorageConfigValidate(t *testing.T) {
 	assert := assert.New(t)
 
 	for _, validConfig := range validNBDStorageConfigs {
-		err := validConfig.Validate(StorageNonDeduped)
+		err := validConfig.Validate()
 		assert.NoErrorf(err, "input: %v", validConfig)
 	}
 
 	for _, invalidConfig := range invalidNBDStorageConfigs {
-		err := invalidConfig.Validate(StorageNonDeduped)
+		err := invalidConfig.Validate()
 		if assert.Errorf(err, "input: %v", invalidConfig) {
 			t.Logf("NBDStorageConfigValidate error: %v", err)
 		}
 	}
 }
 
-func TestNBDStorageConfigValidateDeduped(t *testing.T) {
-	assert := assert.New(t)
-
-	for _, validConfig := range validNBDStorageConfigsDeduped {
-		err := validConfig.Validate(StorageDeduped)
-		assert.NoErrorf(err, "input: %v", validConfig)
-	}
-
-	for _, invalidConfig := range invalidNBDStorageConfigsDeduped {
-		err := invalidConfig.Validate(StorageDeduped)
-		if assert.Errorf(err, "input: %v", invalidConfig) {
-			t.Logf("NBDStorageConfigValidate error: %v", err)
-		}
-	}
-}
-
-func TestTlogStorageConfigValidateNonDeduped(t *testing.T) {
+func TestTlogStorageConfigValidate(t *testing.T) {
 	assert := assert.New(t)
 
 	for _, validConfig := range validTlogStorageConfigs {
-		err := validConfig.Validate(StorageNonDeduped)
+		err := validConfig.Validate()
 		assert.NoErrorf(err, "input: %v", validConfig)
 	}
 
 	for _, invalidConfig := range invalidTlogStorageConfigs {
-		err := invalidConfig.Validate(StorageNonDeduped)
-		if assert.Errorf(err, "input: %v", invalidConfig) {
-			t.Logf("TlogStorageConfigValidate error: %v", err)
-		}
-	}
-}
-
-func TestTlogStorageConfigValidateDeduped(t *testing.T) {
-	assert := assert.New(t)
-
-	for _, validConfig := range validTlogStorageConfigsDeduped {
-		err := validConfig.Validate(StorageDeduped)
-		assert.NoErrorf(err, "input: %v", validConfig)
-	}
-
-	for _, invalidConfig := range invalidTlogStorageConfigsDeduped {
-		err := invalidConfig.Validate(StorageDeduped)
+		err := invalidConfig.Validate()
 		if assert.Errorf(err, "input: %v", invalidConfig) {
 			t.Logf("TlogStorageConfigValidate error: %v", err)
 		}

--- a/config/config_api_test.go
+++ b/config/config_api_test.go
@@ -40,7 +40,7 @@ func TestReadNBDVdisksConfig(t *testing.T) {
 
 	source.SetVdiskConfig("a", nil) // delete it first, so we can properly create it by default
 	source.SetPrimaryStorageCluster("a", "mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
+		Servers: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 	})
 	vdisksCfg, err := ReadNBDVdisksConfig(source, "foo")
 	if assert.NoError(err, "should return us 'a'") && assert.Len(vdisksCfg.Vdisks, 1) {
@@ -87,7 +87,7 @@ func TestReadVdiskStaticConfig(t *testing.T) {
 	source.SetVdiskConfig("a", nil) // delete it first, so we can properly create it by default
 	// add vdisk by default as deduped (boot)
 	source.SetPrimaryStorageCluster("a", "mycluster", &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
+		Servers: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 	})
 
 	_, err = ReadVdiskStaticConfig(source, "a")
@@ -140,7 +140,7 @@ func TestReadStorageClusterConfig(t *testing.T) {
 	testInvalidKey("foo")
 
 	inputCfg := StorageClusterConfig{
-		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
+		Servers: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 	}
 	source.SetStorageCluster("foo", &inputCfg)
 
@@ -154,7 +154,7 @@ func TestReadStorageClusterConfig(t *testing.T) {
 	testInvalidKey("bar")
 
 	inputCfg = StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 			StorageServerConfig{Address: "localhost:16379", Database: 42},
 		},
@@ -482,7 +482,7 @@ func TestWatchStorageClusterConfig(t *testing.T) {
 	testInvalidKey("foo")
 
 	inputCfg := StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 			StorageServerConfig{Address: "localhost:16379", Database: 42},
 		},
@@ -504,12 +504,12 @@ func TestWatchStorageClusterConfig(t *testing.T) {
 	testValue(inputCfg)
 
 	// delete one Data Storage Server
-	inputCfg.DataStorage = inputCfg.DataStorage[0:1]
+	inputCfg.Servers = inputCfg.Servers[0:1]
 	source.SetStorageCluster("foo", &inputCfg)
 	testValue(inputCfg)
 
 	// make invalid, this should make it mark the key as invalid
-	inputCfg.DataStorage = nil
+	inputCfg.Servers = nil
 	source.SetStorageCluster("foo", &inputCfg)
 	testInvalidKey("foo")
 

--- a/config/config_api_test.go
+++ b/config/config_api_test.go
@@ -40,8 +40,7 @@ func TestReadNBDVdisksConfig(t *testing.T) {
 
 	source.SetVdiskConfig("a", nil) // delete it first, so we can properly create it by default
 	source.SetPrimaryStorageCluster("a", "mycluster", &StorageClusterConfig{
-		DataStorage:     []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16379"},
+		DataStorage: []StorageServerConfig{StorageServerConfig{Address: "localhost:16379"}},
 	})
 	vdisksCfg, err := ReadNBDVdisksConfig(source, "foo")
 	if assert.NoError(err, "should return us 'a'") && assert.Len(vdisksCfg.Vdisks, 1) {
@@ -159,7 +158,6 @@ func TestReadStorageClusterConfig(t *testing.T) {
 			StorageServerConfig{Address: "localhost:16379"},
 			StorageServerConfig{Address: "localhost:16379", Database: 42},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16381", Database: 2},
 	}
 	source.SetStorageCluster("bar", &inputCfg)
 
@@ -488,7 +486,6 @@ func TestWatchStorageClusterConfig(t *testing.T) {
 			StorageServerConfig{Address: "localhost:16379"},
 			StorageServerConfig{Address: "localhost:16379", Database: 42},
 		},
-		MetadataStorage: &StorageServerConfig{Address: "localhost:16381", Database: 2},
 	}
 	source.SetStorageCluster("foo", &inputCfg)
 
@@ -504,11 +501,6 @@ func TestWatchStorageClusterConfig(t *testing.T) {
 		}
 	}
 
-	testValue(inputCfg)
-
-	// delete meta Data Storage Server
-	inputCfg.MetadataStorage = nil
-	source.SetStorageCluster("foo", &inputCfg)
 	testValue(inputCfg)
 
 	// delete one Data Storage Server

--- a/config/config_server_validate.go
+++ b/config/config_server_validate.go
@@ -10,7 +10,7 @@ func ValidateNBDServerConfigs(source Source, serverID string) error {
 
 	var errs validateErrors
 	for _, vdiskID := range cfg.Vdisks {
-		_, err = ReadNBDStorageConfig(source, vdiskID, nil)
+		_, err = ReadNBDStorageConfig(source, vdiskID)
 		if err != nil {
 			errs = append(errs, err)
 		}
@@ -33,7 +33,7 @@ func ValidateTlogServerConfigs(source Source, serverID string) error {
 
 	var errs validateErrors
 	for _, vdiskID := range cfg.Vdisks {
-		_, err = ReadTlogStorageConfig(source, vdiskID, nil)
+		_, err = ReadTlogStorageConfig(source, vdiskID)
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/config/format.go
+++ b/config/format.go
@@ -209,7 +209,7 @@ func NewStorageClusterConfig(data []byte) (*StorageClusterConfig, error) {
 // A storage cluster is composed out of multiple data storage servers,
 // and a single (optional) metadata storage.
 type StorageClusterConfig struct {
-	DataStorage []StorageServerConfig `yaml:"dataStorage" valid:"required"`
+	Servers []StorageServerConfig `yaml:"servers" valid:"required"`
 }
 
 // Validate implements FormatValidator.Validate.
@@ -226,7 +226,7 @@ func (cfg *StorageClusterConfig) Validate() error {
 	// validate all data server configs
 	// and ensure that at least one data server is enabled
 	var serversAvailable bool
-	for _, serverConfig := range cfg.DataStorage {
+	for _, serverConfig := range cfg.Servers {
 		err = serverConfig.Validate()
 		if err != nil {
 			return err
@@ -249,8 +249,8 @@ func (cfg *StorageClusterConfig) Clone() StorageClusterConfig {
 		return clone
 	}
 
-	clone.DataStorage = make([]StorageServerConfig, len(cfg.DataStorage))
-	copy(clone.DataStorage, cfg.DataStorage)
+	clone.Servers = make([]StorageServerConfig, len(cfg.Servers))
+	copy(clone.Servers, cfg.Servers)
 
 	return clone
 }
@@ -271,12 +271,12 @@ func (cfg *StorageClusterConfig) Equal(other *StorageClusterConfig) bool {
 
 	// check if the data storage length is equal,
 	// if not than the configs can't be equal
-	if len(cfg.DataStorage) != len(other.DataStorage) {
+	if len(cfg.Servers) != len(other.Servers) {
 		return false
 	}
 	// check if all data storages are equal
-	for i := range cfg.DataStorage {
-		if !cfg.DataStorage[i].Equal(&other.DataStorage[i]) {
+	for i := range cfg.Servers {
+		if !cfg.Servers[i].Equal(&other.Servers[i]) {
 			return false
 		}
 	}
@@ -287,7 +287,7 @@ func (cfg *StorageClusterConfig) Equal(other *StorageClusterConfig) bool {
 
 // FirstAvailableServer returns the first available server.
 func (cfg *StorageClusterConfig) FirstAvailableServer() (*StorageServerConfig, error) {
-	for _, serverCfg := range cfg.DataStorage {
+	for _, serverCfg := range cfg.Servers {
 		if !serverCfg.Disabled {
 			return &serverCfg, nil
 		}

--- a/config/format_data_test.go
+++ b/config/format_data_test.go
@@ -188,23 +188,15 @@ dataStorage:
   - address: 1.1.1.1:11
   - address: 2.2.2.2:22
     db: 2
-metadataStorage:
-  address: 3.3.3.3:33
 `, `
 dataStorage:
   - address: 1.1.1.1:11
-metadataStorage:
-  address: 3.3.3.3:33
 `,
 }
 
 var invalidStorageClusterConfigYAML = []string{
 	"",
-	// dataStorage not given
-	`
-metadataStorage:
-  address: 3.3.3.3:33
-`, // dataStorage given but doesn't contain a single server
+	// dataStorage given but doesn't contain a single server
 	`
 dataStorage:
   foo: bar
@@ -217,12 +209,6 @@ dataStorage:
 	`
 dataStorage:
   address: localhost:16379
-`, // dataStorage given but invalid metadataStorage
-	`
-dataStorage:
-  - address: localhost:16379
-metadataStorage:
-  db: 2
 `, // only disabled data storages given
 	`
 dataStorage:

--- a/config/format_data_test.go
+++ b/config/format_data_test.go
@@ -151,45 +151,39 @@ slaveStorageClusterID: bar
 var validStorageClusterConfigYAML = []string{
 	// complete example
 	`
-dataStorage:
+servers:
   - address: 1.1.1.1:11
     db: 1
   - address: 2.2.2.2:22
     db: 2
-metadataStorage:
-  address: 3.3.3.3:33
-  db: 3
 `, // similar example from above, but using ipv6
 	`
-dataStorage:
+servers:
   - address: "[2001:db8:0:1:1:1:1:1]:11"
     db: 1
   - address: "[2001:db8:0:2:2:2:2:2]:22"
     db: 2
-metadataStorage:
-  address: "[2001:db8:0:3:3:3:3:3]:33"
-  db: 3
 `, // most minimal version of 1 example
 	`
-dataStorage:
+servers:
   - address: 1.1.1.1:11
 `, // most minimal (local) version of 1 example
 	`
-dataStorage:
+servers:
   - address: localhost:16379
 `, // other variations of first example...
 	`
-dataStorage:
+servers:
   - address: 1.1.1.1:11
     db: 1
   - address: 2.2.2.2:22
 `, `
-dataStorage:
+servers:
   - address: 1.1.1.1:11
   - address: 2.2.2.2:22
     db: 2
 `, `
-dataStorage:
+servers:
   - address: 1.1.1.1:11
 `,
 }
@@ -198,20 +192,20 @@ var invalidStorageClusterConfigYAML = []string{
 	"",
 	// dataStorage given but doesn't contain a single server
 	`
-dataStorage:
+servers:
   foo: bar
 `, // dataStorage given but doesn't define the dial string
 	`
-dataStorage:
+servers:
   - db: 2
 `, // dataStorage given but wrong type, requires array of storage servers,
 	// instead a single storage server is given directly
 	`
-dataStorage:
+servers:
   address: localhost:16379
 `, // only disabled data storages given
 	`
-dataStorage:
+servers:
   - address: localhost:16379
     disabled: true
   - disabled: true

--- a/config/format_test.go
+++ b/config/format_test.go
@@ -116,7 +116,7 @@ func TestStorageClusterConfigEqual(t *testing.T) {
 	assert.True(a.Equal(b), "both are nil")
 
 	a = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
 	}
@@ -127,27 +127,27 @@ func TestStorageClusterConfigEqual(t *testing.T) {
 	a = nil
 	assert.False(a.Equal(b), "a is nil")
 	a = &StorageClusterConfig{
-		DataStorage: []StorageServerConfig{
+		Servers: []StorageServerConfig{
 			StorageServerConfig{Address: "localhost:16379"},
 		},
 	}
 	assert.True(a.Equal(b), "should be equal")
 
-	b.DataStorage = append(b.DataStorage, StorageServerConfig{Address: "localhost:16380"})
+	b.Servers = append(b.Servers, StorageServerConfig{Address: "localhost:16380"})
 	assert.False(a.Equal(b), "b has more servers")
-	a.DataStorage = append(a.DataStorage, StorageServerConfig{Address: "localhost:16360"})
+	a.Servers = append(a.Servers, StorageServerConfig{Address: "localhost:16360"})
 	assert.False(a.Equal(b), "equal amount of servers, but different")
-	a.DataStorage[1].Address = "localhost:16380"
+	a.Servers[1].Address = "localhost:16380"
 	assert.True(a.Equal(b), "equal servers")
-	server := a.DataStorage[1]
-	a.DataStorage[1] = a.DataStorage[0]
-	a.DataStorage[0] = server
+	server := a.Servers[1]
+	a.Servers[1] = a.Servers[0]
+	a.Servers[0] = server
 	assert.False(a.Equal(b), "equal servers, but different order")
-	copy(a.DataStorage, b.DataStorage)
+	copy(a.Servers, b.Servers)
 	assert.True(a.Equal(b), "equal servers")
-	a.DataStorage[0].Database = 5
+	a.Servers[0].Database = 5
 	assert.False(a.Equal(b), "almost equal servers, one has different database")
-	b.DataStorage[0].Database = 5
+	b.Servers[0].Database = 5
 
 	b = nil
 	assert.False(a.Equal(b), "b is nil")
@@ -188,9 +188,9 @@ func TestStorageClusterConfigClone(t *testing.T) {
 	var nilCluster *StorageClusterConfig
 	// should be fine, will be just a nil cluster
 	a := nilCluster.Clone()
-	assert.Empty(a.DataStorage)
+	assert.Empty(a.Servers)
 
-	a.DataStorage = []StorageServerConfig{
+	a.Servers = []StorageServerConfig{
 		StorageServerConfig{Address: "localhost:16379"},
 		StorageServerConfig{Address: "localhost:16380"},
 		StorageServerConfig{Address: "localhost:16381"},
@@ -200,9 +200,9 @@ func TestStorageClusterConfigClone(t *testing.T) {
 	assert.True(a.Equal(&b), "should be equal")
 
 	// as b is a clone, we should be able to modify it, without modifying a
-	b.DataStorage[0].Address = "localhost:300"
+	b.Servers[0].Address = "localhost:300"
 	assert.False(a.Equal(&b), "shouldn't be equal")
-	a.DataStorage[0].Address = "localhost:300"
+	a.Servers[0].Address = "localhost:300"
 	assert.True(a.Equal(&b), "should be equal")
 }
 

--- a/config/format_test.go
+++ b/config/format_test.go
@@ -148,20 +148,6 @@ func TestStorageClusterConfigEqual(t *testing.T) {
 	a.DataStorage[0].Database = 5
 	assert.False(a.Equal(b), "almost equal servers, one has different database")
 	b.DataStorage[0].Database = 5
-	assert.True(a.Equal(b), "equal servers")
-
-	a.MetadataStorage = &StorageServerConfig{Address: "localhost:16379"}
-	assert.False(a.Equal(b), "difference because of metadata server")
-	b.MetadataStorage = &StorageServerConfig{Address: "localhost:16380"}
-	assert.False(a.Equal(b), "difference because of metadata server")
-	b.MetadataStorage.Address = "localhost:16379"
-	assert.True(a.Equal(b), "equal servers")
-	b.MetadataStorage.Database = 2
-	assert.False(a.Equal(b), "difference because of metadata server")
-	a.MetadataStorage.Database = 2
-	assert.True(a.Equal(b), "equal servers")
-	a.MetadataStorage = nil
-	assert.False(a.Equal(b), "difference because of metadata server")
 
 	b = nil
 	assert.False(a.Equal(b), "b is nil")
@@ -203,14 +189,12 @@ func TestStorageClusterConfigClone(t *testing.T) {
 	// should be fine, will be just a nil cluster
 	a := nilCluster.Clone()
 	assert.Empty(a.DataStorage)
-	assert.Nil(a.MetadataStorage)
 
 	a.DataStorage = []StorageServerConfig{
 		StorageServerConfig{Address: "localhost:16379"},
 		StorageServerConfig{Address: "localhost:16380"},
 		StorageServerConfig{Address: "localhost:16381"},
 	}
-	a.MetadataStorage = &StorageServerConfig{Address: "localhost:16379"}
 
 	b := a.Clone()
 	assert.True(a.Equal(&b), "should be equal")
@@ -219,12 +203,6 @@ func TestStorageClusterConfigClone(t *testing.T) {
 	b.DataStorage[0].Address = "localhost:300"
 	assert.False(a.Equal(&b), "shouldn't be equal")
 	a.DataStorage[0].Address = "localhost:300"
-	assert.True(a.Equal(&b), "should be equal")
-
-	// this also applies to the metadata storage
-	a.MetadataStorage.Database = 42
-	assert.False(a.Equal(&b), "shouldn't be equal")
-	b.MetadataStorage.Database = 42
 	assert.True(a.Equal(&b), "should be equal")
 }
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -155,24 +155,19 @@ See the [VdiskTlogConfig Godoc][VdiskTlogConfigGodoc] for more information.
 
 Stores [storage(1)][storage] cluster information, referenced by one or multiple [vdisks][vdisk]:
 
-* dataStorage: data ([ARDB][ardb]) servers used to store vdisk and tlog data;
-* metaDataStorage: a single ([ARDB][ardb]) server used to store vdisk [metadata][metadata] (not used by [nondeduped vdisks][nondeduped]);
+* servers: ([ARDB][ardb]) servers used to store vdisk ([meta][metadata])[data][data];
 
 Example Config:
 
 ```yaml
-dataStorage:  # at least one server is required
+servers:  # at least one server is required
   - address: 192.168.1.146:2000 # has to be a valid dial string
     db: 10 # optional, 0 by default
   - address: 192.123.123.1:2001
     db: 10
-metadataStorage: # not used for cache/temp vdisks' storage and template storage,
-                 # required for all other purposes
-  address: 192.168.1.146:2001
-  db: 11
 ```
 
-Used by the [NBD Server][nbdServerConfig].
+Used by the [NBD Server][nbdServerConfig] and [TLog Server][tlogServerConfig] (slave sync).
 
 See the [StorageClusterConfig Godoc][StorageClusterConfigGodoc] for more information.
 
@@ -300,9 +295,6 @@ storageClusters:
       - address: localhost:16379
       - address: localhost:16380
       - address: localhost:16381
-    metadataStorage:
-      address: localhost:16379
-      db: 2
   mastercluster:
     dataStorage:
       - address: localhost:10122
@@ -313,9 +305,6 @@ storageClusters:
       - address: localhost:20122
       - address: localhost:20123
       - address: localhost:20124
-    metadataStorage:
-      address: localhost:16312
-      db: 1
 zeroStorClusters:
   zerostorcluster:
     iyo:

--- a/nbd/ardb/backup/backup.go
+++ b/nbd/ardb/backup/backup.go
@@ -361,7 +361,7 @@ func createBlockStorage(vdiskID string, sourceConfig config.SourceConfig, listIn
 		return nil, err
 	}
 
-	nbdStorageConfig, err := config.ReadNBDStorageConfig(storageConfigCloser, vdiskID, vdiskConfig)
+	nbdStorageConfig, err := config.ReadNBDStorageConfig(storageConfigCloser, vdiskID)
 	if err != nil {
 		return nil, err
 	}

--- a/nbd/ardb/provider.go
+++ b/nbd/ardb/provider.go
@@ -222,14 +222,14 @@ func (rp *staticRedisProvider) Close() error {
 }
 
 func (rp *staticRedisProvider) setConfig(cfg *config.NBDStorageConfig) {
-	rp.dataConnectionConfigs = cfg.StorageCluster.DataStorage
+	rp.dataConnectionConfigs = cfg.StorageCluster.Servers
 	rp.numberOfServers = int64(len(rp.dataConnectionConfigs))
 
 	if cfg.TemplateStorageCluster == nil {
 		rp.templateDataConnectionConfigs = nil
 		rp.numberOfTemplateServers = 0
 	} else {
-		rp.templateDataConnectionConfigs = cfg.TemplateStorageCluster.DataStorage
+		rp.templateDataConnectionConfigs = cfg.TemplateStorageCluster.Servers
 		rp.numberOfTemplateServers = int64(len(rp.templateDataConnectionConfigs))
 	}
 }

--- a/nbd/ardb/storage/deduped.go
+++ b/nbd/ardb/storage/deduped.go
@@ -279,7 +279,7 @@ func DedupedVdiskExists(vdiskID string, cluster *config.StorageClusterConfig) (b
 	// go through each server to check if the vdisKID exists there
 	// the first vdisk which has data for this vdisk,
 	// we'll take as a sign that the vdisk exists
-	for _, serverConfig := range cluster.DataStorage {
+	for _, serverConfig := range cluster.Servers {
 		exists, err := dedupedVdiskExistsOnServer(key, serverConfig)
 		if exists || err != nil {
 			return exists, err
@@ -315,7 +315,7 @@ func ListDedupedBlockIndices(vdiskID string, cluster *config.StorageClusterConfi
 	// from all the different data servers which make up the given storage cluster.
 	var err error
 	var serverIndices []int64
-	for _, server := range cluster.DataStorage {
+	for _, server := range cluster.Servers {
 		serverIndices, err = listDedupedBlockIndices(key, server)
 		if err != nil {
 			if err == redis.ErrNil {
@@ -356,7 +356,7 @@ func CopyDeduped(sourceID, targetID string, sourceCluster, targetCluster *config
 	if sourceCluster == nil {
 		return errors.New("no source cluster given")
 	}
-	sourceDataServerCount := len(sourceCluster.DataStorage)
+	sourceDataServerCount := len(sourceCluster.Servers)
 	if sourceDataServerCount == 0 {
 		return errors.New("no data server configs given for source")
 	}
@@ -366,7 +366,7 @@ func CopyDeduped(sourceID, targetID string, sourceCluster, targetCluster *config
 	if targetCluster == nil {
 		targetCluster = sourceCluster
 	} else {
-		targetDataServerCount := len(targetCluster.DataStorage)
+		targetDataServerCount := len(targetCluster.Servers)
 		// [TODO]
 		// Currently the result will be WRONG in case targetDataServerCount != sourceDataServerCount,
 		// as the storage data spread will not be the same,
@@ -382,8 +382,8 @@ func CopyDeduped(sourceID, targetID string, sourceCluster, targetCluster *config
 	var sourceCfg, targetCfg config.StorageServerConfig
 
 	for i := 0; i < sourceDataServerCount; i++ {
-		sourceCfg = sourceCluster.DataStorage[i]
-		targetCfg = targetCluster.DataStorage[i]
+		sourceCfg = sourceCluster.Servers[i]
+		targetCfg = targetCluster.Servers[i]
 
 		if sourceCfg.Equal(&targetCfg) {
 			// within same storage server

--- a/nbd/ardb/storage/deduped.go
+++ b/nbd/ardb/storage/deduped.go
@@ -272,16 +272,32 @@ func DedupedVdiskExists(vdiskID string, cluster *config.StorageClusterConfig) (b
 	if cluster == nil {
 		return false, errors.New("no cluster config given")
 	}
-	if cluster.MetadataStorage == nil {
-		return false, errors.New("no metadataServer given for cluster config")
+
+	// storage key used on all data servers for this vdisk
+	key := lba.StorageKey(vdiskID)
+
+	// go through each server to check if the vdisKID exists there
+	// the first vdisk which has data for this vdisk,
+	// we'll take as a sign that the vdisk exists
+	for _, serverConfig := range cluster.DataStorage {
+		exists, err := dedupedVdiskExistsOnServer(key, serverConfig)
+		if exists || err != nil {
+			return exists, err
+		}
 	}
 
-	conn, err := ardb.GetConnection(*cluster.MetadataStorage)
+	// no errors occured, but no server had the given storage key,
+	// which means the vdisk doesn't exist
+	return false, nil
+}
+
+func dedupedVdiskExistsOnServer(key string, server config.StorageServerConfig) (bool, error) {
+	conn, err := ardb.GetConnection(server)
 	if err != nil {
-		return false, fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+		return false, fmt.Errorf("couldn't connect to data ardb: %s", err.Error())
 	}
 	defer conn.Close()
-	return redis.Bool(conn.Do("EXISTS", lba.StorageKey(vdiskID)))
+	return redis.Bool(conn.Do("EXISTS", key))
 }
 
 // ListDedupedBlockIndices returns all indices stored for the given deduped storage.
@@ -291,22 +307,46 @@ func ListDedupedBlockIndices(vdiskID string, cluster *config.StorageClusterConfi
 	if cluster == nil {
 		return nil, errors.New("no cluster config given")
 	}
-	if cluster.MetadataStorage == nil {
-		return nil, errors.New("no metadataServer given for cluster config")
+
+	var vdiskIndices []int64
+	key := lba.StorageKey(vdiskID)
+
+	// collect all deduped block indices
+	// from all the different data servers which make up the given storage cluster.
+	var err error
+	var serverIndices []int64
+	for _, server := range cluster.DataStorage {
+		serverIndices, err = listDedupedBlockIndices(key, server)
+		if err != nil {
+			if err == redis.ErrNil {
+				continue
+			}
+			return nil, err
+		}
+
+		vdiskIndices = append(vdiskIndices, serverIndices...)
 	}
 
-	conn, err := ardb.GetConnection(*cluster.MetadataStorage)
+	// if no vdisk indices are found on any of the given storage servers,
+	// we'll return a redis nil-error, such that the user can decide
+	// if they want to threat it as an error or not
+	if len(vdiskIndices) == 0 {
+		return nil, redis.ErrNil
+	}
+
+	// at least one index is found,
+	// make sure it's sorted in ascending order and return them all.
+	sortInt64s(vdiskIndices)
+	return vdiskIndices, nil
+}
+
+func listDedupedBlockIndices(key string, server config.StorageServerConfig) ([]int64, error) {
+	conn, err := ardb.GetConnection(server)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+		return nil, fmt.Errorf("couldn't connect to data ardb: %s", err.Error())
 	}
 	defer conn.Close()
-	indices, err := ardb.RedisInt64s(listDedupedBlockIndicesScript.Do(conn, lba.StorageKey(vdiskID)))
-	if err != nil {
-		return nil, err
-	}
-
-	sortInt64s(indices)
-	return indices, nil
+	return ardb.RedisInt64s(listDedupedBlockIndicesScript.Do(conn, key))
 }
 
 // CopyDeduped copies all metadata of a deduped storage
@@ -316,52 +356,68 @@ func CopyDeduped(sourceID, targetID string, sourceCluster, targetCluster *config
 	if sourceCluster == nil {
 		return errors.New("no source cluster given")
 	}
-	if sourceCluster.MetadataStorage == nil {
-		return errors.New("no metadataServer given for source")
+	sourceDataServerCount := len(sourceCluster.DataStorage)
+	if sourceDataServerCount == 0 {
+		return errors.New("no data server configs given for source")
 	}
 
-	// define whether or not we're copying between different servers,
+	// define whether or not we're copying between different clusters,
 	// and if the target cluster is given, make sure to validate it.
-	var sameServer bool
 	if targetCluster == nil {
-		sameServer = true
-		if sourceID == targetID {
-			return errors.New(
-				"sourceID and targetID can't be equal when copying within the same cluster")
-		}
+		targetCluster = sourceCluster
 	} else {
-		if targetCluster.MetadataStorage == nil {
-			return errors.New("no metaDataServer given for target")
+		targetDataServerCount := len(targetCluster.DataStorage)
+		// [TODO]
+		// Currently the result will be WRONG in case targetDataServerCount != sourceDataServerCount,
+		// as the storage data spread will not be the same,
+		// to what the nbdserver read calls will expect.
+		// See open issue for more information:
+		// https://github.com/zero-os/0-Disk/issues/206
+		if targetDataServerCount != sourceDataServerCount {
+			return errors.New("target data server count has to equal the source data server count")
 		}
-
-		// even if targetCluster is given,
-		// we could still be dealing with a duplicated cluster
-		sameServer = *sourceCluster.MetadataStorage == *targetCluster.MetadataStorage
 	}
 
-	// within same storage server
-	if sameServer {
-		conn, err := ardb.GetConnection(*sourceCluster.MetadataStorage)
+	var err error
+	var sourceCfg, targetCfg config.StorageServerConfig
+
+	for i := 0; i < sourceDataServerCount; i++ {
+		sourceCfg = sourceCluster.DataStorage[i]
+		targetCfg = targetCluster.DataStorage[i]
+
+		if sourceCfg.Equal(&targetCfg) {
+			// within same storage server
+			err = func() error {
+				conn, err := ardb.GetConnection(sourceCfg)
+				if err != nil {
+					return fmt.Errorf("couldn't connect to data ardb: %s", err.Error())
+				}
+				defer conn.Close()
+
+				return copyDedupedSameConnection(sourceID, targetID, conn)
+			}()
+		} else {
+			// between different storage servers
+			err = func() error {
+				conns, err := ardb.GetConnections(sourceCfg, targetCfg)
+				if err != nil {
+					return fmt.Errorf("couldn't connect to data ardb: %s", err.Error())
+				}
+				defer func() {
+					conns[0].Close()
+					conns[1].Close()
+				}()
+
+				return copyDedupedDifferentConnections(sourceID, targetID, conns[0], conns[1])
+			}()
+		}
+
 		if err != nil {
-			return fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+			return err
 		}
-		defer conn.Close()
-
-		return copyDedupedSameConnection(sourceID, targetID, conn)
 	}
 
-	// between different storage servers
-	conns, err := ardb.GetConnections(
-		*sourceCluster.MetadataStorage, *targetCluster.MetadataStorage)
-	if err != nil {
-		return fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
-	}
-	defer func() {
-		conns[0].Close()
-		conns[1].Close()
-	}()
-
-	return copyDedupedDifferentConnections(sourceID, targetID, conns[0], conns[1])
+	return nil
 }
 
 func copyDedupedSameConnection(sourceID, targetID string, conn redis.Conn) (err error) {
@@ -388,8 +444,7 @@ func copyDedupedDifferentConnections(sourceID, targetID string, connA, connB red
 	}
 	dataLength := len(data)
 	if dataLength == 0 {
-		err = fmt.Errorf("%q does not exist", sourceID)
-		return
+		return // nothing to do
 	}
 
 	log.Infof("collected %d meta indices from source vdisk %q",

--- a/nbd/ardb/storage/deduped_test.go
+++ b/nbd/ardb/storage/deduped_test.go
@@ -562,7 +562,7 @@ func TestListDedupedBlockIndices(t *testing.T) {
 	redisProvider := redisstub.NewInMemoryRedisProvider(nil)
 	address := redisProvider.PrimaryAddress()
 	clusterConfig := config.StorageClusterConfig{
-		DataStorage: []config.StorageServerConfig{
+		Servers: []config.StorageServerConfig{
 			config.StorageServerConfig{
 				Address: address,
 			},

--- a/nbd/ardb/storage/deduped_test.go
+++ b/nbd/ardb/storage/deduped_test.go
@@ -567,9 +567,6 @@ func TestListDedupedBlockIndices(t *testing.T) {
 				Address: address,
 			},
 		},
-		MetadataStorage: &config.StorageServerConfig{
-			Address: address,
-		},
 	}
 
 	storage, err := Deduped(

--- a/nbd/ardb/storage/lba/lba.go
+++ b/nbd/ardb/storage/lba/lba.go
@@ -24,7 +24,7 @@ func StorageKey(vdiskID string) string {
 }
 
 // NewLBA creates a new LBA
-func NewLBA(vdiskID string, cacheLimitInBytes int64, provider ardb.MetadataConnProvider) (lba *LBA, err error) {
+func NewLBA(vdiskID string, cacheLimitInBytes int64, provider ardb.DataConnProvider) (lba *LBA, err error) {
 	if vdiskID == "" {
 		return nil, errors.New("NewLBA requires non-empty vdiskID")
 	}
@@ -99,7 +99,7 @@ func (lba *LBA) Get(blockIndex int64) (zerodisk.Hash, error) {
 	return bucket.GetHash(blockIndex)
 }
 
-// Flush stores all dirty sectors to the external metadaserver
+// Flush stores all dirty sectors to the external storage
 func (lba *LBA) Flush() error {
 	var wg sync.WaitGroup
 	var errors flushError

--- a/nbd/ardb/storage/nondeduped.go
+++ b/nbd/ardb/storage/nondeduped.go
@@ -231,7 +231,7 @@ func NonDedupedVdiskExists(vdiskID string, cluster *config.StorageClusterConfig)
 	// go through each server to check if the vdisKID exists there
 	// the first vdisk which has data for this vdisk,
 	// we'll take as a sign that the vdisk exists
-	for _, serverConfig := range cluster.DataStorage {
+	for _, serverConfig := range cluster.Servers {
 		exists, err := nonDedupedVdiskExistsOnServer(key, serverConfig)
 		if exists || err != nil {
 			return exists, err
@@ -266,7 +266,7 @@ func ListNonDedupedBlockIndices(vdiskID string, cluster *config.StorageClusterCo
 
 	var indices []int64
 	// collect the indices found on each data server
-	for _, serverConfig := range cluster.DataStorage {
+	for _, serverConfig := range cluster.Servers {
 		serverIndices, err := listNonDedupedBlockIndicesOnDataServer(key, serverConfig)
 		if err == redis.ErrNil {
 			log.Infof(
@@ -308,7 +308,7 @@ func CopyNonDeduped(sourceID, targetID string, sourceCluster, targetCluster *con
 	if sourceCluster == nil {
 		return errors.New("no source cluster given")
 	}
-	sourceDataServerCount := len(sourceCluster.DataStorage)
+	sourceDataServerCount := len(sourceCluster.Servers)
 	if sourceDataServerCount == 0 {
 		return errors.New("no data server configs given for source")
 	}
@@ -318,7 +318,7 @@ func CopyNonDeduped(sourceID, targetID string, sourceCluster, targetCluster *con
 	if targetCluster == nil {
 		targetCluster = sourceCluster
 	} else {
-		targetDataServerCount := len(targetCluster.DataStorage)
+		targetDataServerCount := len(targetCluster.Servers)
 		// [TODO]
 		// Currently the result will be WRONG in case targetDataServerCount != sourceDataServerCount,
 		// as the storage data spread will not be the same,
@@ -334,8 +334,8 @@ func CopyNonDeduped(sourceID, targetID string, sourceCluster, targetCluster *con
 	var sourceCfg, targetCfg config.StorageServerConfig
 
 	for i := 0; i < sourceDataServerCount; i++ {
-		sourceCfg = sourceCluster.DataStorage[i]
-		targetCfg = targetCluster.DataStorage[i]
+		sourceCfg = sourceCluster.Servers[i]
+		targetCfg = targetCluster.Servers[i]
 
 		if sourceCfg.Equal(&targetCfg) {
 			// within same storage server

--- a/nbd/ardb/storage/nondeduped_test.go
+++ b/nbd/ardb/storage/nondeduped_test.go
@@ -419,7 +419,7 @@ func TestListNonDedupedBlockIndices(t *testing.T) {
 		blockCount = 16
 	)
 
-	redisProvider := redisstub.NewInMemoryRedisProviderMultiServers(4, 0, false)
+	redisProvider := redisstub.NewInMemoryRedisProviderMultiServers(4, 0)
 	defer redisProvider.Close()
 	clusterConfig := redisProvider.ClusterConfig()
 

--- a/nbd/ardb/storage/semideduped.go
+++ b/nbd/ardb/storage/semideduped.go
@@ -229,7 +229,7 @@ func CopySemiDeduped(sourceID, targetID string, sourceCluster, targetCluster *co
 	if sourceCluster == nil {
 		return errors.New("no source cluster given")
 	}
-	sourceDataServerCount := len(sourceCluster.DataStorage)
+	sourceDataServerCount := len(sourceCluster.Servers)
 	if sourceDataServerCount == 0 {
 		return errors.New("no data server configs given for source")
 	}
@@ -239,7 +239,7 @@ func CopySemiDeduped(sourceID, targetID string, sourceCluster, targetCluster *co
 	if targetCluster == nil {
 		targetCluster = sourceCluster
 	} else {
-		targetDataServerCount := len(targetCluster.DataStorage)
+		targetDataServerCount := len(targetCluster.Servers)
 		// [TODO]
 		// Currently the result will be WRONG in case targetDataServerCount != sourceDataServerCount,
 		// as the storage data spread will not be the same,
@@ -289,8 +289,8 @@ func CopySemiDeduped(sourceID, targetID string, sourceCluster, targetCluster *co
 	var sourceCfg, targetCfg config.StorageServerConfig
 
 	for i := 0; i < sourceDataServerCount; i++ {
-		sourceCfg = sourceCluster.DataStorage[i]
-		targetCfg = targetCluster.DataStorage[i]
+		sourceCfg = sourceCluster.Servers[i]
+		targetCfg = targetCluster.Servers[i]
 
 		if sourceCfg.Equal(&targetCfg) {
 			// within same storage server

--- a/nbd/ardb/storage/storage.go
+++ b/nbd/ardb/storage/storage.go
@@ -266,10 +266,7 @@ func DeleteMetadata(cfg config.StorageServerConfig, vdisks map[string]config.Vdi
 	var pipeline storageOpPipeline
 
 	for vdiskID, vdiskType := range vdisks {
-		switch vdiskType.StorageType() {
-		case config.StorageDeduped:
-			pipeline.Add(newDeleteDedupedMetadataOp(vdiskID))
-		case config.StorageSemiDeduped:
+		if vdiskType.StorageType() == config.StorageSemiDeduped {
 			pipeline.Add(newDeleteSemiDedupedMetaDataOp(vdiskID))
 		}
 	}
@@ -283,10 +280,13 @@ func DeleteData(cfg config.StorageServerConfig, vdisks map[string]config.VdiskTy
 
 	for vdiskID, vdiskType := range vdisks {
 		switch vdiskType.StorageType() {
+		case config.StorageDeduped:
+			pipeline.Add(newDeleteDedupedMetadataOp(vdiskID))
 		case config.StorageNonDeduped:
 			pipeline.Add(newDeleteNonDedupedDataOp(vdiskID))
 		case config.StorageSemiDeduped:
-			pipeline.Add(newDeleteSemiDedupedDataOp(vdiskID))
+			pipeline.Add(newDeleteDedupedMetadataOp(vdiskID))
+			pipeline.Add(newDeleteNonDedupedDataOp(vdiskID))
 		}
 	}
 

--- a/nbd/nbdserver/tlog/tlog.go
+++ b/nbd/nbdserver/tlog/tlog.go
@@ -1043,45 +1043,36 @@ func CopyMetadata(sourceID, targetID string, sourceCluster, targetCluster *confi
 	if sourceCluster == nil {
 		return errors.New("no source cluster given")
 	}
-	if sourceCluster.MetadataStorage == nil {
-		return errors.New("no metadataServer given for source")
-	}
 
-	// define whether or not we're copying between different servers,
-	// and if the target cluster is given, make sure to validate it.
-	var sameServer bool
+	// define whether or not we're copying between different servers.
 	if targetCluster == nil {
-		sameServer = true
-		if sourceID == targetID {
-			return errors.New(
-				"sourceID and targetID can't be equal when copying within the same cluster")
-		}
-	} else {
-		if targetCluster.MetadataStorage == nil {
-			return errors.New("no metaDataServer given for target")
-		}
-
-		// even if targetCluster is given,
-		// we could still be dealing with a duplicated cluster
-		sameServer = *sourceCluster.MetadataStorage == *targetCluster.MetadataStorage
+		targetCluster = sourceCluster
 	}
 
-	// within same storage server
-	if sameServer {
-		conn, err := ardb.GetConnection(*sourceCluster.MetadataStorage)
+	// get first available storage server
+
+	metaSourceCfg, err := sourceCluster.FirstAvailableServer()
+	if err != nil {
+		return err
+	}
+	metaTargetCfg, err := targetCluster.FirstAvailableServer()
+	if err != nil {
+		return err
+	}
+
+	if metaSourceCfg.Equal(metaTargetCfg) {
+		conn, err := ardb.GetConnection(*metaSourceCfg)
 		if err != nil {
-			return fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+			return fmt.Errorf("couldn't connect to ardb: %s", err.Error())
 		}
 		defer conn.Close()
 
 		return copyMetadataSameConnection(sourceID, targetID, conn)
 	}
 
-	// between different storage servers
-	conns, err := ardb.GetConnections(
-		*sourceCluster.MetadataStorage, *targetCluster.MetadataStorage)
+	conns, err := ardb.GetConnections(*metaSourceCfg, *metaTargetCfg)
 	if err != nil {
-		return fmt.Errorf("couldn't connect to meta ardb: %s", err.Error())
+		return fmt.Errorf("couldn't connect to ardb: %s", err.Error())
 	}
 	defer func() {
 		conns[0].Close()

--- a/redisstub/redis.go
+++ b/redisstub/redis.go
@@ -320,7 +320,7 @@ func (rp *InMemoryRedisProviderMultiServers) ClusterConfig() *config.StorageClus
 	cluster := new(config.StorageClusterConfig)
 
 	for _, memRedis := range rp.memRedisSlice {
-		cluster.DataStorage = append(cluster.DataStorage, config.StorageServerConfig{
+		cluster.Servers = append(cluster.Servers, config.StorageServerConfig{
 			Address: memRedis.Address(),
 		})
 	}

--- a/tlog/copy/generator.go
+++ b/tlog/copy/generator.go
@@ -45,7 +45,7 @@ func (g *generator) GenerateFromStorage(parentCtx context.Context) error {
 		return err
 	}
 
-	storageConf, err := config.ReadNBDStorageConfig(g.configSource, g.sourceVdiskID, staticConf)
+	storageConf, err := config.ReadNBDStorageConfig(g.configSource, g.sourceVdiskID)
 	if err != nil {
 		return fmt.Errorf("failed to ReadNBDStorageConfig: %v", err)
 	}

--- a/tlog/copy/generator_test.go
+++ b/tlog/copy/generator_test.go
@@ -65,7 +65,7 @@ func TestGenerate(t *testing.T) {
 	confSource.SetVdiskConfig(targetVdiskID, &staticConf)
 
 	storageClusterConf := &config.StorageClusterConfig{
-		DataStorage: []config.StorageServerConfig{
+		Servers: []config.StorageServerConfig{
 			config.StorageServerConfig{
 				Address: redisProvider.PrimaryAddress(),
 			},

--- a/tlog/copy/generator_test.go
+++ b/tlog/copy/generator_test.go
@@ -70,7 +70,6 @@ func TestGenerate(t *testing.T) {
 				Address: redisProvider.PrimaryAddress(),
 			},
 		},
-		MetadataStorage: &config.StorageServerConfig{Address: redisProvider.PrimaryAddress()},
 	}
 
 	confSource.SetPrimaryStorageCluster(sourceVdiskID, nbdClusterID, storageClusterConf)

--- a/tlog/tlogclient/player/player.go
+++ b/tlog/tlogclient/player/player.go
@@ -39,7 +39,7 @@ func NewPlayer(ctx context.Context, source config.Source,
 	if err != nil {
 		return nil, err
 	}
-	nbdCfg, err := config.ReadNBDStorageConfig(source, vdiskID, vdiskCfg)
+	nbdCfg, err := config.ReadNBDStorageConfig(source, vdiskID)
 	if err != nil {
 		return nil, err
 	}

--- a/tlog/tlogserver/slavesync_test.go
+++ b/tlog/tlogserver/slavesync_test.go
@@ -162,7 +162,7 @@ func newZeroStorConfig(t *testing.T, vdiskID, privKey string,
 
 	storageClusterID := "cluster_id_for_slave"
 	storageCluserConf := &config.StorageClusterConfig{
-		DataStorage: []config.StorageServerConfig{
+		Servers: []config.StorageServerConfig{
 			config.StorageServerConfig{
 				Address: ardbAddress,
 			}},

--- a/tlog/tlogserver/slavesync_test.go
+++ b/tlog/tlogserver/slavesync_test.go
@@ -166,9 +166,6 @@ func newZeroStorConfig(t *testing.T, vdiskID, privKey string,
 			config.StorageServerConfig{
 				Address: ardbAddress,
 			}},
-		MetadataStorage: &config.StorageServerConfig{
-			Address: ardbAddress,
-		},
 	}
 
 	stubSource.SetSlaveStorageCluster(vdiskID, storageClusterID, storageCluserConf)

--- a/zeroctl/cmd/backup/import.go
+++ b/zeroctl/cmd/backup/import.go
@@ -116,7 +116,7 @@ func checkVdiskExists(vdiskID string) error {
 	}
 
 	// delete data
-	for _, serverConfig := range nbdStorageConfig.StorageCluster.DataStorage {
+	for _, serverConfig := range nbdStorageConfig.StorageCluster.Servers {
 		err := storage.DeleteData(serverConfig, vdisks)
 		if err != nil {
 			return fmt.Errorf(

--- a/zeroctl/cmd/backup/import.go
+++ b/zeroctl/cmd/backup/import.go
@@ -11,6 +11,7 @@ import (
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbd/ardb/backup"
 	"github.com/zero-os/0-Disk/nbd/ardb/storage"
+	"github.com/zero-os/0-Disk/nbd/nbdserver/tlog"
 
 	cmdconfig "github.com/zero-os/0-Disk/zeroctl/cmd/config"
 )
@@ -73,7 +74,7 @@ func checkVdiskExists(vdiskID string) error {
 		return fmt.Errorf(
 			"cannot read static vdisk config for vdisk %s: %v", vdiskID, err)
 	}
-	nbdStorageConfig, err := config.ReadNBDStorageConfig(configSource, vdiskID, staticConfig)
+	nbdStorageConfig, err := config.ReadNBDStorageConfig(configSource, vdiskID)
 	if err != nil {
 		return fmt.Errorf(
 			"cannot read nbd storage config for vdisk %s: %v", vdiskID, err)
@@ -94,18 +95,27 @@ func checkVdiskExists(vdiskID string) error {
 
 	vdisks := map[string]config.VdiskType{vdiskID: staticConfig.Type}
 
-	// delete metadata (if needed)
-	if nbdStorageConfig.StorageCluster.MetadataStorage != nil {
-		cfg := nbdStorageConfig.StorageCluster.MetadataStorage
-		err := storage.DeleteMetadata(*cfg, vdisks)
-		if err != nil {
-			return fmt.Errorf(
-				"couldn't delete metadata for vdisk %s from %s@%d: %v",
-				vdiskID, cfg.Address, cfg.Database, err)
-		}
+	// delete metadata
+	serverConfig, err := nbdStorageConfig.StorageCluster.FirstAvailableServer()
+	if err != nil {
+		return err
+	}
+	err = storage.DeleteMetadata(*serverConfig, vdisks)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't delete metadata for vdisks from %s@%d: %v",
+			serverConfig.Address, serverConfig.Database, err)
+	}
+	// make this easier
+	// see: https://github.com/zero-os/0-Disk/issues/481
+	err = deleteTlogMetadata(*serverConfig, vdisks)
+	if err != nil {
+		return fmt.Errorf(
+			"couldn't delete tlog metadata for vdisks from %s@%d: %v",
+			serverConfig.Address, serverConfig.Database, err)
 	}
 
-	// delete data (if needed)
+	// delete data
 	for _, serverConfig := range nbdStorageConfig.StorageCluster.DataStorage {
 		err := storage.DeleteData(serverConfig, vdisks)
 		if err != nil {
@@ -117,6 +127,22 @@ func checkVdiskExists(vdiskID string) error {
 
 	// vdisk did exist, but we were able to delete all the exiting (meta)data
 	return nil
+}
+
+func deleteTlogMetadata(serverCfg config.StorageServerConfig, vdiskMap map[string]config.VdiskType) error {
+	var vdisks []string
+	for vdiskID, vdiskType := range vdiskMap {
+		if vdiskType.TlogSupport() {
+			vdisks = append(vdisks, vdiskID)
+		}
+	}
+
+	// TODO: ensure that vdisk also have an active tlog configuration,
+	//       as this is still optional even though it might support it type-wise.
+	// TODO: also delete actual tlog meta(data) from 0-Stor cluster for the supported vdisks
+	//       https://github.com/zero-os/0-Disk/issues/147
+
+	return tlog.DeleteMetadata(serverCfg, vdisks...)
 }
 
 func parseImportPosArguments(args []string) error {

--- a/zeroctl/cmd/copyvdisk/vdisk.go
+++ b/zeroctl/cmd/copyvdisk/vdisk.go
@@ -71,7 +71,7 @@ func copyVdisk(cmd *cobra.Command, args []string) error {
 			"couldn't read source vdisk %s's static config: %v", sourceVdiskID, err)
 	}
 	sourceStorageConfig, err := config.ReadNBDStorageConfig(
-		configSource, sourceVdiskID, sourceStaticConfig)
+		configSource, sourceVdiskID)
 	if err != nil {
 		return fmt.Errorf(
 			"couldn't read source vdisk %s's storage config: %v", sourceVdiskID, err)

--- a/zeroctl/cmd/delvdisk/vdisks.go
+++ b/zeroctl/cmd/delvdisk/vdisks.go
@@ -129,7 +129,7 @@ func getAndSortVdisks(vdiskIDs []string, configSource config.Source) (data vdisk
 			}
 		}
 
-		for _, serverCfg := range cfg.DataStorage {
+		for _, serverCfg := range cfg.Servers {
 			data.AddVdisk(serverCfg, vdiskID, vdiskType)
 		}
 	}

--- a/zeroctl/cmd/restore/vdisk.go
+++ b/zeroctl/cmd/restore/vdisk.go
@@ -127,7 +127,7 @@ func checkVdiskExists(vdiskID string, configSource config.Source) error {
 	}
 
 	// delete data
-	for _, serverConfig := range nbdStorageConfig.StorageCluster.DataStorage {
+	for _, serverConfig := range nbdStorageConfig.StorageCluster.Servers {
 		err := storage.DeleteData(serverConfig, vdisks)
 		if err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
closes #306

- [x] remove metadata server from 0-Disk;
- [x] spread deduped LBA metadata over all data servers of a deduped vdisk's storage cluster;
- [x] rename `StorageClusterConfig`'s `dataStorage` to `servers` (as it now will contain both metadata and data);
- [x] update all relevant documentation;