### PR TITLE
add missing ardb network error broadcasts

### DIFF
--- a/nbd/ardb/storage/deduped_test.go
+++ b/nbd/ardb/storage/deduped_test.go
@@ -392,7 +392,7 @@ func TestDedupedStorageTemplateServerDown(t *testing.T) {
 	}
 
 	// now mark template invalid, and that should make it return an expected error instead
-	redisProviderB.MarkTemplateConnectionInvalid(-1)
+	redisProviderB.DisableTemplateConnection(0)
 	content, err = storageB.GetBlock(someIndexPlusOne)
 	if len(content) != 0 {
 		t.Fatalf("content should be empty but was was: %v",

--- a/nbd/ardb/storage/nondeduped_test.go
+++ b/nbd/ardb/storage/nondeduped_test.go
@@ -276,7 +276,7 @@ func TestNonDedupedStorageTemplateServerDown(t *testing.T) {
 	}
 
 	// now mark template invalid, and that should make it return an expected error instead
-	redisProviderB.MarkTemplateConnectionInvalid(-1)
+	redisProviderB.DisableTemplateConnection(0)
 	content, err = storageB.GetBlock(someIndexPlusOne)
 	if len(content) != 0 {
 		t.Fatalf("content should be empty but was was: %v",


### PR DESCRIPTION
fixes #492

There's quite a lot of code duplication, but that is OK for now. This only shows that the design of the storage code as it is is really getting stretched over its limits.

In the new design _this_ broadcasting will be centralized and part of a the bigger picture error handling, and thus not be all over the place.