### PR TITLE
nbd : don't return error in case it needs to sync with tlog.

### DIFF
--- a/nbd/nbdserver/tlog/tlog.go
+++ b/nbd/nbdserver/tlog/tlog.go
@@ -59,8 +59,7 @@ func Storage(ctx context.Context, vdiskID, clusterID string, configSource config
 			// TODO call tlog player if last flushed sequence from tlog server is
 			// higher than us.
 			// see: https://github.com/zero-os/0-Disk/issues/230
-			cancel()
-			return nil, fmt.Errorf("error when starting vdisk `%v`: need to sync with tlog", vdiskID)
+			log.Infof("possile error when starting vdisk `%v`: might need to sync with tlog", vdiskID)
 		}
 	}
 


### PR DESCRIPTION
Some reasons:
- the sync feature still in todo
- the check (whether we need to sync or not) itself still not tested
- it also the old behaviour