### PR TITLE
tlog : prepend vdisk ID to the data to generate unique hash.

### DIFF
--- a/tlog/stor/client.go
+++ b/tlog/stor/client.go
@@ -135,7 +135,7 @@ func (c *Client) ProcessStore(blocks []*schema.TlogBlock) ([]byte, error) {
 		return nil, err
 	}
 
-	key := c.hasher.Hash(data)
+	key := c.hasher.Hash(append([]byte(c.vdiskID), data...))
 
 	// it is very first data, save first key to metadata server
 	if c.firstMetaKey == nil {


### PR DESCRIPTION
It was relied on the fact that aggregation contains vdiskID.
But vdiskID has been removed at 0809ea4db380df30edb382e962d1d8c2bbfab4ec