### PR TITLE
fix codegen scripts, ci and tests

### DIFF
--- a/scripts/codegeneration.sh
+++ b/scripts/codegeneration.sh
@@ -2,22 +2,36 @@
 
 generate_and_check() {
     DIR=$1
+    echo "testing 'go generate' of \"$DIR\""
 
     # Perform code generation and verify that the git repository is still clean,
     # meaning that any newly-generated code was added in this commit.
-    go generate "$DIR"
-
-    GITSTATUS=$(git status --porcelain)
-    if [ -z "$GITSTATUS" ]; then
-        exit 0
+    if go generate "$DIR"; then
+        echo "succesfully generated \"$DIR\""
+    else
+        echo "failed to generate \"$DIR\""
+        exit 1
     fi
 
-    # turns out that that there are uncomitted changes possible
-    # in the generated code, exit with an error
-    echo -e "changes detected, run 'go generate \"$DIR\"' and commit generated code in these files:\n"
-    echo "$GITSTATUS"
-    exit 1
+    if GITSTATUS=$(git status --porcelain); then
+        if [ -z "$GITSTATUS" ]; then
+            echo "output of 'go generate \"$DIR\"' is up to date"
+        else
+            # turns out that that there are uncomitted changes possible
+            # in the generated code, exit with an error
+            echo -e "changes detected, run 'go generate \"$DIR\"' and commit generated code in these files:\n"
+            echo "$GITSTATUS"
+            exit 1
+        fi
+    else
+        echo "failed get git status"
+        exit 1
+    fi
 }
 
 generate_and_check ./tlog
-generate_and_check ./docs/assets
+
+# there is no good way for now to have this cross-platform,
+# produce reproducable results, and it doesn't impact (production) code either,
+# so for now not doing it makes sense
+#generate_and_check ./docs/assets

--- a/scripts/install_capnp_unix.sh
+++ b/scripts/install_capnp_unix.sh
@@ -7,3 +7,6 @@ cd capnproto-c++-0.6.1 || (echo "couldn't download capnproto-c++-0.6.0" && exit 
 ./configure
 sudo make install
 cd "$ORIGDIR" && sudo rm -rf capnproto-c++-0.6.1
+
+BASEDIR=$(dirname "$0")
+"$BASEDIR"/install_capnpc_go_plugin.sh

--- a/scripts/install_capnpc_go_plugin.sh
+++ b/scripts/install_capnpc_go_plugin.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# install the vendored go-capnpc plugin
+# (required by capnp exe for generating Go code)
+VENDOR_DIR="github.com/zero-os/0-Disk/vendor"
+PLUGIN_DIR="zombiezen.com/go/capnproto2/capnpc-go"
+echo "installing vendored capnpc-go plugin..."
+go install -v "$VENDOR_DIR/$PLUGIN_DIR"

--- a/tlog/schema/tlog_schema.capnp.go
+++ b/tlog/schema/tlog_schema.capnp.go
@@ -76,6 +76,11 @@ func (s HandshakeRequest_List) Set(i int, v HandshakeRequest) error {
 	return s.List.SetStruct(i, v.Struct)
 }
 
+func (s HandshakeRequest_List) String() string {
+	str, _ := text.MarshalList(0xe0d4e6d68fa24ac0, s.List)
+	return str
+}
+
 // HandshakeRequest_Promise is a wrapper for a HandshakeRequest promised by a client call.
 type HandshakeRequest_Promise struct{ *capnp.Pipeline }
 
@@ -148,6 +153,11 @@ func (s HandshakeResponse_List) At(i int) HandshakeResponse {
 
 func (s HandshakeResponse_List) Set(i int, v HandshakeResponse) error {
 	return s.List.SetStruct(i, v.Struct)
+}
+
+func (s HandshakeResponse_List) String() string {
+	str, _ := text.MarshalList(0xee959a7d96c96641, s.List)
+	return str
 }
 
 // HandshakeResponse_Promise is a wrapper for a HandshakeResponse promised by a client call.
@@ -270,6 +280,11 @@ func (s TlogAggregation_List) At(i int) TlogAggregation { return TlogAggregation
 
 func (s TlogAggregation_List) Set(i int, v TlogAggregation) error {
 	return s.List.SetStruct(i, v.Struct)
+}
+
+func (s TlogAggregation_List) String() string {
+	str, _ := text.MarshalList(0xe46ab5b4b619e094, s.List)
+	return str
 }
 
 // TlogAggregation_Promise is a wrapper for a TlogAggregation promised by a client call.
@@ -398,6 +413,11 @@ func (s TlogClientMessage_List) Set(i int, v TlogClientMessage) error {
 	return s.List.SetStruct(i, v.Struct)
 }
 
+func (s TlogClientMessage_List) String() string {
+	str, _ := text.MarshalList(0xc8407b23fdf6d1a2, s.List)
+	return str
+}
+
 // TlogClientMessage_Promise is a wrapper for a TlogClientMessage promised by a client call.
 type TlogClientMessage_Promise struct{ *capnp.Pipeline }
 
@@ -508,6 +528,11 @@ func (s TlogBlock_List) At(i int) TlogBlock { return TlogBlock{s.List.Struct(i)}
 
 func (s TlogBlock_List) Set(i int, v TlogBlock) error { return s.List.SetStruct(i, v.Struct) }
 
+func (s TlogBlock_List) String() string {
+	str, _ := text.MarshalList(0x8cf178de3c82d431, s.List)
+	return str
+}
+
 // TlogBlock_Promise is a wrapper for a TlogBlock promised by a client call.
 type TlogBlock_Promise struct{ *capnp.Pipeline }
 
@@ -586,6 +611,11 @@ func NewTlogResponse_List(s *capnp.Segment, sz int32) (TlogResponse_List, error)
 func (s TlogResponse_List) At(i int) TlogResponse { return TlogResponse{s.List.Struct(i)} }
 
 func (s TlogResponse_List) Set(i int, v TlogResponse) error { return s.List.SetStruct(i, v.Struct) }
+
+func (s TlogResponse_List) String() string {
+	str, _ := text.MarshalList(0x98d11ae1c78a24d9, s.List)
+	return str
+}
 
 // TlogResponse_Promise is a wrapper for a TlogResponse promised by a client call.
 type TlogResponse_Promise struct{ *capnp.Pipeline }


### PR DESCRIPTION
+ ensure that the codegeneration.sh script fails if a subcommand fails (fixes #533);
+ update the outdated auto-generated tlog/schema/tlog_schema.capnp.go file;
+ ensure that the install_capnp_unix.sh installs the vendored capnpc-go plugin as well (fixes #343);
+ ensure that codegeneration.sh script keeps testing targets while succesfull (fixes #535);