### PR TITLE
tlogclient : do not log io.EOF error on stopped client.

### DIFF
--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -221,7 +221,9 @@ func (c *Client) runReceiver(ctx context.Context, cancelFunc context.CancelFunc)
 
 				// EOF and other network error triggers reconnection
 				if isNetErr || err == io.EOF {
-					log.Errorf("error while reading: %v", err)
+					if !c.isStopped() {
+						log.Errorf("error while reading: %v", err)
+					}
 					return
 				}
 


### PR DESCRIPTION
Fixes #522