### PR TITLE
remaining packages now use 0-Disk/errors

### DIFF
--- a/log/broadcast.go
+++ b/log/broadcast.go
@@ -1,8 +1,7 @@
 package log
 
 import (
-	"errors"
-
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-log"
 )
 

--- a/log/handler_go19.go
+++ b/log/handler_go19.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-stack/stack"
 	log "github.com/inconshreveable/log15"
+	"github.com/zero-os/0-Disk/errors"
 )
 
 // Handler interface defines where and how log records are written.
@@ -28,7 +29,7 @@ func StderrHandler() Handler {
 func FileHandler(path string) (Handler, error) {
 	handler, err := log.FileHandler(path, log.LogfmtFormat())
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create FileHandler: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't create FileHandler")
 	}
 
 	return handler, nil
@@ -39,7 +40,7 @@ func FileHandler(path string) (Handler, error) {
 func SyslogHandler(tag string) (Handler, error) {
 	handler, err := log.SyslogHandler(syslog.LOG_KERN, tag, log.LogfmtFormat())
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create SyslogHandler: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't create SyslogHandler")
 	}
 
 	return handler, nil
@@ -73,5 +74,5 @@ func newLoggerHandler(level Level, extraStackDepth int, handlers []Handler) log.
 	}
 
 	return log.LvlFilterHandler(log.Lvl(level),
-	callerFileHandler(8+extraStackDepth, logHandler))
+		callerFileHandler(8+extraStackDepth, logHandler))
 }

--- a/log/handler_pre_go19.go
+++ b/log/handler_pre_go19.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-stack/stack"
 	log "github.com/inconshreveable/log15"
+	"github.com/zero-os/0-Disk/errors"
 )
 
 // Handler interface defines where and how log records are written.
@@ -30,7 +31,7 @@ func StderrHandler() Handler {
 func FileHandler(path string) (Handler, error) {
 	handler, err := log.FileHandler(path, log.LogfmtFormat())
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create FileHandler: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't create FileHandler")
 	}
 
 	return &fromLog15Handler{handler}, nil
@@ -41,7 +42,7 @@ func FileHandler(path string) (Handler, error) {
 func SyslogHandler(tag string) (Handler, error) {
 	handler, err := log.SyslogHandler(syslog.LOG_KERN, tag, log.LogfmtFormat())
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create SyslogHandler: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't create SyslogHandler")
 	}
 
 	return &fromLog15Handler{handler}, nil

--- a/tlog/aggregation.go
+++ b/tlog/aggregation.go
@@ -2,11 +2,10 @@ package tlog
 
 import (
 	"bytes"
-	"errors"
 
-	"zombiezen.com/go/capnproto2"
-
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/tlog/schema"
+	"zombiezen.com/go/capnproto2"
 )
 
 var (

--- a/tlog/status.go
+++ b/tlog/status.go
@@ -1,8 +1,7 @@
 package tlog
 
 import (
-	"errors"
-	"fmt"
+	"github.com/zero-os/0-Disk/errors"
 )
 
 // BlockStatus is returned by the Tlog server
@@ -45,7 +44,7 @@ func (status BlockStatus) Error() error {
 	case BlockStatusRecvFailed:
 		return errors.New("didn't receive the tlog block")
 	default:
-		return fmt.Errorf("invalid connection with unknown status: %d", status)
+		return errors.Newf("invalid connection with unknown status: %d", status)
 	}
 }
 
@@ -107,7 +106,7 @@ func (status HandshakeStatus) Error() error {
 	case HandshakeStatusInvalidRequest:
 		return errors.New("client's HandshakeRequest could not be decoded")
 	default:
-		return fmt.Errorf("invalid connection with unknown status: %d", status)
+		return errors.Newf("invalid connection with unknown status: %d", status)
 	}
 }
 

--- a/tlog/stor/client.go
+++ b/tlog/stor/client.go
@@ -314,7 +314,7 @@ func (c *Client) LoadLastSequence() (uint64, error) {
 		return 0, err
 	}
 	if blocks.Len() == 0 {
-		return 0, errors.Newf("empty blocks for aggregation")
+		return 0, errors.New("empty blocks for aggregation")
 	}
 
 	c.lastMetaKey = wr.Key

--- a/tlog/stor/client.go
+++ b/tlog/stor/client.go
@@ -1,18 +1,17 @@
 package stor
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 
-	storclient "github.com/zero-os/0-stor/client"
-	"github.com/zero-os/0-stor/client/lib/hash"
-	"github.com/zero-os/0-stor/client/meta"
-
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/tlog"
 	"github.com/zero-os/0-Disk/tlog/schema"
+	storclient "github.com/zero-os/0-stor/client"
+	"github.com/zero-os/0-stor/client/lib/hash"
+	"github.com/zero-os/0-stor/client/meta"
 )
 
 const (
@@ -172,7 +171,7 @@ func (c *Client) processStoreData(data []byte, lastSequence uint64, timestamp in
 		return err
 	}
 	if lastMd == nil {
-		return fmt.Errorf("empty meta returned by stor client")
+		return errors.Newf("empty meta returned by stor client")
 	}
 
 	// it is very first data, save first key to metadata server
@@ -297,7 +296,7 @@ func (c *Client) LoadLastSequence() (uint64, error) {
 
 	// it should never happen
 	if wr == nil {
-		return 0, fmt.Errorf("failed to walk on vdisk %v", c.vdiskID)
+		return 0, errors.Newf("failed to walk on vdisk %v", c.vdiskID)
 	}
 
 	if wr.Error != nil {
@@ -315,7 +314,7 @@ func (c *Client) LoadLastSequence() (uint64, error) {
 		return 0, err
 	}
 	if blocks.Len() == 0 {
-		return 0, fmt.Errorf("empty blocks for aggregation")
+		return 0, errors.Newf("empty blocks for aggregation")
 	}
 
 	c.lastMetaKey = wr.Key

--- a/tlog/stor/client.go
+++ b/tlog/stor/client.go
@@ -171,7 +171,7 @@ func (c *Client) processStoreData(data []byte, lastSequence uint64, timestamp in
 		return err
 	}
 	if lastMd == nil {
-		return errors.Newf("empty meta returned by stor client")
+		return errors.New("empty meta returned by stor client")
 	}
 
 	// it is very first data, save first key to metadata server

--- a/tlog/support.go
+++ b/tlog/support.go
@@ -1,17 +1,16 @@
 package tlog
 
 import (
-	"fmt"
-
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 )
 
 // HasTlogCluster returns true if the given vdiskID has tlog clusters
 func HasTlogCluster(confSource config.Source, vdiskID string) (bool, error) {
 	staticConf, err := config.ReadVdiskStaticConfig(confSource, vdiskID)
 	if err != nil {
-		return false, fmt.Errorf(
-			"couldn't read vdisk %s's static config: %v", vdiskID, err)
+		return false, errors.Wrapf(err,
+			"couldn't read vdisk %s's static config", vdiskID)
 	}
 
 	if !staticConf.Type.TlogSupport() {
@@ -20,8 +19,8 @@ func HasTlogCluster(confSource config.Source, vdiskID string) (bool, error) {
 
 	nbdConf, err := config.ReadVdiskNBDConfig(confSource, vdiskID)
 	if err != nil {
-		return false, fmt.Errorf(
-			"couldn't read vdisk %s's NBD vdisk config: %v", vdiskID, err)
+		return false, errors.Wrapf(err,
+			"couldn't read vdisk %s's NBD vdisk config", vdiskID)
 	}
 
 	return nbdConf.TlogServerClusterID != "", nil

--- a/tlog/tlogclient/capnp.go
+++ b/tlog/tlogclient/capnp.go
@@ -1,10 +1,10 @@
 package tlogclient
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/zero-os/0-Disk"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/tlog/schema"
 	"zombiezen.com/go/capnproto2"
 )
@@ -12,19 +12,19 @@ import (
 func (c *Client) encodeHandshakeCapnp() error {
 	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(c.capnpSegmentBuf))
 	if err != nil {
-		return fmt.Errorf("failed to build (handshake) capnp: %s", err.Error())
+		return errors.Wrap(err, "failed to build (handshake) capnp")
 	}
 
 	handshake, err := schema.NewRootHandshakeRequest(seg)
 	if err != nil {
-		return fmt.Errorf("couldn't create handshake: %s", err.Error())
+		return errors.Wrap(err, "couldn't create handshake")
 	}
 
 	handshake.SetVersion(zerodisk.CurrentVersion.UInt32())
 
 	err = handshake.SetVdiskID(c.vdiskID)
 	if err != nil {
-		return fmt.Errorf("couldn't set handshake vdiskID: %s", err.Error())
+		return errors.Wrap(err, "couldn't set handshake vdiskID")
 	}
 
 	return capnp.NewEncoder(c.bw).Encode(msg)
@@ -33,26 +33,26 @@ func (c *Client) encodeHandshakeCapnp() error {
 func encodeBlockCapnp(w io.Writer, op uint8, seq uint64, index int64, hash []byte, timestamp int64, data, segmentBuf []byte) (*schema.TlogBlock, error) {
 	msg, seg, err := capnp.NewMessage(capnp.SingleSegment(segmentBuf))
 	if err != nil {
-		return nil, fmt.Errorf("failed to build build (block) capnp: %s", err.Error())
+		return nil, errors.Wrap(err, "failed to build build (block) capnp")
 	}
 
 	cmd, err := schema.NewRootTlogClientMessage(seg)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create client message: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't create client message")
 	}
 
 	block, err := schema.NewTlogBlock(seg)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create block: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't create block")
 	}
 
 	err = block.SetHash(hash)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't set block hash: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't set block hash")
 	}
 	err = block.SetData(data)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't set block data: %s", err.Error())
+		return nil, errors.Wrap(err, "couldn't set block data")
 	}
 
 	block.SetOperation(op)

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -576,7 +576,7 @@ func (c *Client) Disconnect() error {
 	select {
 	case <-time.After(10 * time.Second):
 		c.signalCond(c.disconnectedCond)
-		return errors.Newf("disconnect timed out")
+		return errors.New("disconnect timed out")
 	case <-doneCh:
 		return nil
 	}

--- a/tlog/tlogclient/client.go
+++ b/tlog/tlogclient/client.go
@@ -3,13 +3,12 @@ package tlogclient
 import (
 	"bufio"
 	"context"
-	"errors"
-	"fmt"
 	"io"
 	"net"
 	"sync"
 	"time"
 
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/tlog"
 	"github.com/zero-os/0-Disk/tlog/tlogclient/blockbuffer"
@@ -220,7 +219,7 @@ func (c *Client) runReceiver(ctx context.Context, cancelFunc context.CancelFunc)
 				}
 
 				// EOF and other network error triggers reconnection
-				if isNetErr || err == io.EOF {
+				if isNetErr || errors.Cause(err) == io.EOF {
 					if !c.isStopped() {
 						log.Errorf("error while reading: %v", err)
 					}
@@ -357,14 +356,14 @@ func (c *Client) connect() (err error) {
 	c.setCurServerFailedFlushStatus(false)
 
 	if err = c.createConn(); err != nil {
-		return fmt.Errorf("client couldn't be created: %s", err.Error())
+		return errors.Wrap(err, "client couldn't be created")
 	}
 
 	if err = c.handshake(); err != nil {
 		if errClose := c.conn.Close(); errClose != nil {
 			log.Debug("couldn't close open connection of invalid client:", errClose)
 		}
-		return fmt.Errorf("client handshake failed: %s", err.Error())
+		return errors.Wrap(err, "client handshake failed")
 	}
 	return nil
 }
@@ -577,7 +576,7 @@ func (c *Client) Disconnect() error {
 	select {
 	case <-time.After(10 * time.Second):
 		c.signalCond(c.disconnectedCond)
-		return fmt.Errorf("disconnect timed out")
+		return errors.Newf("disconnect timed out")
 	case <-doneCh:
 		return nil
 	}

--- a/tlog/tlogclient/decoder/last_hash.go
+++ b/tlog/tlogclient/decoder/last_hash.go
@@ -1,7 +1,7 @@
 package decoder
 
 import (
-	"errors"
+	"github.com/zero-os/0-Disk/errors"
 )
 
 var (

--- a/tlog/tlogclient/examples/send_tlog/client.go
+++ b/tlog/tlogclient/examples/send_tlog/client.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"sync"
 
+	"github.com/pkg/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/tlog"
 	"github.com/zero-os/0-Disk/tlog/schema"
@@ -59,7 +60,7 @@ func main() {
 		for {
 			r := <-respChan
 			if r.Err != nil {
-				if r.Err == io.EOF {
+				if errors.Cause(r.Err) == io.EOF {
 					continue
 				}
 				log.Fatalf("resp error:%v", r.Err)

--- a/tlog/tlogclient/player/player.go
+++ b/tlog/tlogclient/player/player.go
@@ -2,9 +2,9 @@ package player
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/nbd/ardb"
 	"github.com/zero-os/0-Disk/nbd/ardb/storage"
 	"github.com/zero-os/0-Disk/tlog/schema"
@@ -140,14 +140,14 @@ func (p *Player) ReplayAggregationWithCallback(agg *schema.TlogAggregation, lmt 
 		case schema.OpSet:
 			data, err = block.Data()
 			if err != nil {
-				return seq - 1, fmt.Errorf("failed to get data block %v, err=%v", index, err)
+				return seq - 1, errors.Wrapf(err, "failed to get data block %v", index)
 			}
 			if err = p.blockStorage.SetBlock(index, data); err != nil {
-				return seq - 1, fmt.Errorf("failed to set block %v, err=%v", index, err)
+				return seq - 1, errors.Wrapf(err, "failed to set block %v", index)
 			}
 		case schema.OpDelete:
 			if err = p.blockStorage.DeleteBlock(index); err != nil {
-				return seq - 1, fmt.Errorf("failed to delete block %v, err=%v", index, err)
+				return seq - 1, errors.Wrapf(err, "failed to delete block %v", index)
 			}
 		}
 

--- a/tlog/tlogclient/readme.md
+++ b/tlog/tlogclient/readme.md
@@ -78,7 +78,7 @@ func main() {
 		for {
 			r := <-respChan
 			if r.Err != nil {
-				if r.Err == io.EOF {
+				if errors.Cause(r.Err) == io.EOF {
 					continue
 				}
 				log.Fatalf("resp error:%v", r.Err)

--- a/tlog/tlogserver/aggmq/aggmq.go
+++ b/tlog/tlogserver/aggmq/aggmq.go
@@ -1,10 +1,11 @@
 package aggmq
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
+
+	"github.com/zero-os/0-Disk/errors"
 )
 
 var (

--- a/tlog/tlogserver/aggmq/comm.go
+++ b/tlog/tlogserver/aggmq/comm.go
@@ -1,8 +1,9 @@
 package aggmq
 
 import (
-	"errors"
 	"time"
+
+	"github.com/zero-os/0-Disk/errors"
 )
 
 const (

--- a/tlog/tlogserver/server/vdisk_conn.go
+++ b/tlog/tlogserver/server/vdisk_conn.go
@@ -3,17 +3,15 @@ package server
 import (
 	"bufio"
 	"context"
-	"errors"
-	"fmt"
 	"io"
 	"net"
 
-	"zombiezen.com/go/capnproto2"
-
 	"github.com/zero-os/0-Disk"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/tlog"
 	"github.com/zero-os/0-Disk/tlog/schema"
+	"zombiezen.com/go/capnproto2"
 )
 
 func (vd *vdisk) handle(conn *net.TCPConn, br *bufio.Reader, respSegmentBufLen int) error {
@@ -31,7 +29,7 @@ func (vd *vdisk) handle(conn *net.TCPConn, br *bufio.Reader, respSegmentBufLen i
 		// decode message
 		msg, err := capnp.NewDecoder(br).Decode()
 		if err != nil {
-			if err == io.EOF {
+			if errors.Cause(err) == io.EOF {
 				return nil // EOF in this stage is not an error
 			}
 			return err
@@ -62,7 +60,7 @@ func (vd *vdisk) handle(conn *net.TCPConn, br *bufio.Reader, respSegmentBufLen i
 			log.Infof("vdisk `%v` receive disconnect command", vd.id)
 			return nil
 		default:
-			err = fmt.Errorf("%v is not a supported client message type", which)
+			err = errors.Newf("%v is not a supported client message type", which)
 		}
 
 		if err != nil {
@@ -183,7 +181,7 @@ func (vd *vdisk) attachConn(conn *net.TCPConn) error {
 	defer vd.clientConnLock.Unlock()
 
 	if vd.clientConn != nil {
-		return fmt.Errorf("there is already conencted client for vdisk `%v`", vd.id)
+		return errors.Newf("there is already conencted client for vdisk `%v`", vd.id)
 	}
 
 	vd.clientConn = conn

--- a/tlog/tlogserver/server/vdisk_conn.go
+++ b/tlog/tlogserver/server/vdisk_conn.go
@@ -176,6 +176,7 @@ func (vd *vdisk) hash(tlb *schema.TlogBlock) (err error) {
 
 	return
 }
+
 func (vd *vdisk) attachConn(conn *net.TCPConn) error {
 	vd.clientConnLock.Lock()
 	defer vd.clientConnLock.Unlock()

--- a/zeroctl/cmd/backup/backup.go
+++ b/zeroctl/cmd/backup/backup.go
@@ -1,12 +1,11 @@
 package backup
 
 import (
-	"errors"
-	"fmt"
 	"os"
 	"strings"
 
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/nbd/ardb/backup"
 )
 
@@ -86,7 +85,7 @@ func newStorageConfig(data string) (cfg storageConfig, err error) {
 	}
 
 	// invalid data given, cannot create a config based on it
-	err = fmt.Errorf("%v is an invalid storage config resource string", data)
+	err = errors.Newf("%v is an invalid storage config resource string", data)
 	return
 }
 

--- a/zeroctl/cmd/backup/describe.go
+++ b/zeroctl/cmd/backup/describe.go
@@ -2,10 +2,10 @@ package backup
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbd/ardb/backup"
 

--- a/zeroctl/cmd/backup/export.go
+++ b/zeroctl/cmd/backup/export.go
@@ -2,12 +2,12 @@ package backup
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"runtime"
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbd/ardb/backup"
 

--- a/zeroctl/cmd/backup/import.go
+++ b/zeroctl/cmd/backup/import.go
@@ -2,15 +2,13 @@ package backup
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"runtime"
-
-	"github.com/zero-os/0-Disk/nbd/ardb"
 
 	"github.com/spf13/cobra"
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbd/ardb"
 	"github.com/zero-os/0-Disk/nbd/ardb/backup"
 	"github.com/zero-os/0-Disk/nbd/ardb/storage"
 	"github.com/zero-os/0-Disk/tlog"
@@ -136,48 +134,48 @@ func checkVdiskExists(vdiskID string) error {
 	// gather configs
 	staticConfig, err := config.ReadVdiskStaticConfig(configSource, vdiskID)
 	if err != nil {
-		return fmt.Errorf(
-			"cannot read static vdisk config for vdisk %s: %v", vdiskID, err)
+		return errors.Wrapf(err,
+			"cannot read static vdisk config for vdisk %s", vdiskID)
 	}
 	nbdStorageConfig, err := config.ReadVdiskNBDConfig(configSource, vdiskID)
 	if err != nil {
-		return fmt.Errorf(
-			"cannot read nbd storage config for vdisk %s: %v", vdiskID, err)
+		return errors.Wrapf(err,
+			"cannot read nbd storage config for vdisk %s", vdiskID)
 	}
 	clusterConfig, err := config.ReadStorageClusterConfig(configSource, nbdStorageConfig.StorageClusterID)
 	if err != nil {
-		return fmt.Errorf(
-			"cannot read storage cluster config for cluster %s: %v",
-			nbdStorageConfig.StorageClusterID, err)
+		return errors.Wrapf(err,
+			"cannot read storage cluster config for cluster %s",
+			nbdStorageConfig.StorageClusterID)
 	}
 
 	// create (primary) storage cluster
 	cluster, err := ardb.NewCluster(*clusterConfig, nil) // not pooled
 	if err != nil {
-		return fmt.Errorf(
-			"cannot create storage cluster model for cluster %s: %v",
-			nbdStorageConfig.StorageClusterID, err)
+		return errors.Wrapf(err,
+			"cannot create storage cluster model for cluster %s",
+			nbdStorageConfig.StorageClusterID)
 	}
 
 	// check if vdisk exists
 	exists, err := storage.VdiskExists(vdiskID, staticConfig.Type, cluster)
 	if err != nil {
-		return fmt.Errorf("couldn't check if vdisk %s already exists: %v", vdiskID, err)
+		return errors.Wrapf(err, "couldn't check if vdisk %s already exists", vdiskID)
 	}
 	if !exists {
 		return nil // vdisk doesn't exist, so nothing to do
 	}
 	if !vdiskCmdCfg.Force {
-		return fmt.Errorf("cannot restore vdisk %s as it already exists", vdiskID)
+		return errors.Newf("cannot restore vdisk %s as it already exists", vdiskID)
 	}
 
 	// delete vdisk, as it exists and `--force` is specified
 	deleted, err := storage.DeleteVdisk(vdiskID, staticConfig.Type, cluster)
 	if err != nil {
-		return fmt.Errorf("couldn't delete vdisk %s: %v", vdiskID, err)
+		return errors.Wrapf(err, "couldn't delete vdisk %s", vdiskID)
 	}
 	if !deleted {
-		return fmt.Errorf("couldn't delete vdisk %s for an unknown reason", vdiskID)
+		return errors.Newf("couldn't delete vdisk %s for an unknown reason", vdiskID)
 	}
 
 	// delete 0-Stor (meta)data for this vdisk

--- a/zeroctl/cmd/backup/list.go
+++ b/zeroctl/cmd/backup/list.go
@@ -1,14 +1,13 @@
 package backup
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
 	"github.com/spf13/cobra"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbd/ardb/backup"
-
 	cmdconfig "github.com/zero-os/0-Disk/zeroctl/cmd/config"
 )
 
@@ -35,7 +34,7 @@ func listSnapshots(cmd *cobra.Command, args []string) error {
 	if listSnapshotsCmdCfg.NameRegexp != "" {
 		regexp, err := regexp.Compile(listSnapshotsCmdCfg.NameRegexp)
 		if err != nil {
-			return fmt.Errorf("invalid regexp given for `--name`: %v", err)
+			return errors.Wrap(err, "invalid regexp given for `--name`")
 		}
 		pred = regexp.MatchString
 	}
@@ -50,7 +49,7 @@ func listSnapshots(cmd *cobra.Command, args []string) error {
 	}
 	if len(snapshotIDs) == 0 {
 		if pred != nil {
-			return fmt.Errorf(
+			return errors.Newf(
 				"no snapshots could be find at %s whose identifier match `%s`",
 				vdiskCmdCfg.BackupStorageConfig.String(), listSnapshotsCmdCfg.NameRegexp)
 		}

--- a/zeroctl/cmd/copyvdisk/vdisk.go
+++ b/zeroctl/cmd/copyvdisk/vdisk.go
@@ -2,15 +2,14 @@ package copyvdisk
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"runtime"
 
-	"github.com/zero-os/0-Disk/nbd/ardb"
-
 	"github.com/spf13/cobra"
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbd/ardb"
 	"github.com/zero-os/0-Disk/nbd/ardb/storage"
 	"github.com/zero-os/0-Disk/tlog/copy"
 	tlogserver "github.com/zero-os/0-Disk/tlog/tlogserver/server"
@@ -152,22 +151,22 @@ func checkVdiskExists(id string, t config.VdiskType, cluster ardb.StorageCluster
 	// check if vdisk exists
 	exists, err := storage.VdiskExists(id, t, cluster)
 	if err != nil {
-		return fmt.Errorf("couldn't check if vdisk %s already exists: %v", id, err)
+		return errors.Wrapf(err, "couldn't check if vdisk %s already exists", id)
 	}
 	if !exists {
 		return nil // vdisk doesn't exist, so nothing to do
 	}
 	if !vdiskCmdCfg.Force {
-		return fmt.Errorf("cannot copy to vdisk %s as it already exists", id)
+		return errors.Newf("cannot copy to vdisk %s as it already exists", id)
 	}
 
 	// delete vdisk, as it exists and `--force` is specified
 	deleted, err := storage.DeleteVdisk(id, t, cluster)
 	if err != nil {
-		return fmt.Errorf("couldn't delete vdisk %s: %v", id, err)
+		return errors.Wrapf(err, "couldn't delete vdisk %s", id)
 	}
 	if !deleted {
-		return fmt.Errorf("couldn't delete vdisk %s for an unknown reason", id)
+		return errors.Newf("couldn't delete vdisk %s for an unknown reason", id)
 	}
 
 	// delete 0-Stor (meta)data for this vdisk

--- a/zeroctl/cmd/delvdisk/vdisk.go
+++ b/zeroctl/cmd/delvdisk/vdisk.go
@@ -1,10 +1,9 @@
 package delvdisk
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 	"github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
 	"github.com/zero-os/0-Disk/nbd/ardb"
 	"github.com/zero-os/0-Disk/nbd/ardb/storage"

--- a/zeroctl/cmd/list/vdisks.go
+++ b/zeroctl/cmd/list/vdisks.go
@@ -1,16 +1,15 @@
 package list
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 
-	"github.com/zero-os/0-Disk/nbd/ardb"
-	"github.com/zero-os/0-Disk/nbd/ardb/storage"
-
 	"github.com/spf13/cobra"
 	zerodiskcfg "github.com/zero-os/0-Disk/config"
+	"github.com/zero-os/0-Disk/errors"
 	"github.com/zero-os/0-Disk/log"
+	"github.com/zero-os/0-Disk/nbd/ardb"
+	"github.com/zero-os/0-Disk/nbd/ardb/storage"
 	"github.com/zero-os/0-Disk/zeroctl/cmd/config"
 )
 
@@ -53,7 +52,7 @@ func listVdisks(cmd *cobra.Command, args []string) error {
 	if vdisksCmdCfg.NameRegexp != "" {
 		regexp, err := regexp.Compile(vdisksCmdCfg.NameRegexp)
 		if err != nil {
-			return fmt.Errorf("invalid regexp given for `--name`: %v", err)
+			return errors.Wrap(err, "invalid regexp given for `--name`")
 		}
 		pred = regexp.MatchString
 	}
@@ -65,7 +64,7 @@ func listVdisks(cmd *cobra.Command, args []string) error {
 	}
 	if len(vdiskIDs) == 0 {
 		if pred != nil {
-			return fmt.Errorf(
+			return errors.Newf(
 				"no vdisks could be find in %s whose identifier match `%s`",
 				args[0], vdisksCmdCfg.NameRegexp)
 		}


### PR DESCRIPTION
Following packages now use `0-Disk/errors`:
* tlog
* log
* tools
* zeroctl

Closes #579, closes #580 and therefor finally closes #529 